### PR TITLE
[Region 2] Mapunit Comparison Report v3.0

### DIFF
--- a/inst/reports/region2/mu-comparison/categorical_definitions.R
+++ b/inst/reports/region2/mu-comparison/categorical_definitions.R
@@ -1,0 +1,90 @@
+###TODO: EXTRACT DESCRIPTION FROM XML METADATA OF RASTER?
+
+categorical.defs[['curvature']] <- list(header="Slope Shape (Curvature) Summary",
+                                        # set names: from Field Guide for description of soils
+                                        ## source data: opposite convention
+                                        # 1's place: profile curvature
+                                        # 10's place: plan curvature
+                                        #
+                                        ## adapted from above
+                                        ## data are reported down/across slope
+                                        # L/L | L/V | L/C         22 | 32 | 12  
+                                        # V/L | V/V | V/C   ----> 23 | 33 | 13
+                                        # C/L | C/V | C/C         21 | 31 | 11
+                                        #
+                                        # order according to approximate "shedding" -> "accumulating" gradient:
+                                        # 'V/V', 'L/V', 'V/L', 'C/V', 'LL', 'C/L', 'V/C', 'L/C', 'C/C'
+                                        description="Curvature classes were generated using a 5x5 moving window and a regional 30m or 10m integer DEM. The precision may be limited, so use with caution. See instructions for using your own (higher resolution) curvature classification raster. The conventions used here are \"C\" = concave, \"L\" = linear, and \"V\" = convex; \"down slope\" / \"across slope\". Window size has a significant impact on reported curvature classes; larger windows = more generalization. Curvature class and colors are aligned with an idealized *shedding* &rarr; *accumulating* hydrologic gradient.",
+                                        usage="Use the graphical summary to identify patterns, then consult the tabular representation for specifics.\n* ",
+                                        decimals=2,
+                                        levels = c(33, 32, 23, 31, 22, 21, 13, 12, 11), 
+                                        labels = c('VV', 'LV', 'VL', 'CV', 'LL', 'CL', 'VC', 'LC', 'CC'),
+                                        colors=brewer.pal(9, 'Spectral'),
+                                        keep.all.classes=TRUE)
+
+categorical.defs[['geomorphon']] <- list(header="Geomorphon Landform Classification",
+                                         description="Proportion of samples within each map unit that correspond to 1 of 10 possible landform positions, as generated via [geomorphon](https://grass.osgeo.org/grass70/manuals/addons/r.geomorphon.html) algorithm. Landform classification by [this method](http://dx.doi.org/10.1016/j.geomorph.2012.11.005) is scale-invariant and is therefore not affected by computational window size selection. Landform class labels and colors are aligned with an idealized *shedding* &rarr; *accumulating* hydrologic gradient. \"Flat\" is based on a 3% slope threshold.Map units are organized (in the figure) according to the similarity, computed from proportions of each landform position. The [dendrogram](http://ncss-tech.github.io/stats_for_soil_survey/chapter_5.html) on the right side of the figure describes relative similarity. \"Lower branch height\" (e.g. closer to the right-hand side of the figure) denotes more similar landform positions.",
+                                         usage="Use the graphical summary to identify patterns, then consult the tabular representation for specifics.",
+                                         decimals=2,
+                                         levels=1:10, 
+                                         labels = c('flat', 'summit', 'ridge', 'shoulder', 'spur', 'slope', 'hollow', 'footslope', 'valley', 'depression'),
+                                         colors=c('grey', brewer.pal(9, 'Spectral')),
+                                         keep.all.classes=TRUE)
+
+categorical.defs[['nlcd']] <- list(header="National Land Cover Dataset (NLCD)",
+                                   description="These values are from the [2011 NLCD](https://www.mrlc.gov/nlcd2011.php) (30m) database.",
+                                   usage="Use the graphical summary to identify patterns, then consult the tabular representation for specifics.",
+                                   decimals=2,
+                                   levels = c(0L, 11L, 12L, 21L, 22L, 23L, 24L, 31L, 41L, 42L, 43L, 51L, 52L, 71L, 72L, 73L, 74L, 81L, 82L, 90L, 95L), 
+                                   labels = c("nodata", "Open Water", "Perennial Ice/Snow", "Developed, Open Space", 
+                                              "Developed, Low Intensity", "Developed, Medium Intensity", "Developed, High Intensity", 
+                                              "Barren Land (Rock/Sand/Clay)", "Deciduous Forest", "Evergreen Forest", 
+                                              "Mixed Forest", "Dwarf Scrub", "Shrub/Scrub", "Grassland/Herbaceous", 
+                                              "Sedge/Herbaceous", "Lichens", "Moss", "Pasture/Hay", "Cultivated Crops", 
+                                              "Woody Wetlands", "Emergent Herbaceous Wetlands"),
+                                   colors = c("#000000",  "#476BA0", "#D1DDF9", "#DDC9C9", "#D89382", "#ED0000", "#AA0000", 
+                                              "#B2ADA3", "#68AA63", "#1C6330", "#B5C98E", "#A58C30", "#CCBA7C", 
+                                              "#E2E2C1", "#C9C977", "#99C147", "#77AD93", "#DBD83D", "#AA7028", 
+                                              "#BAD8EA", "#70A3BA"))
+
+categorical.defs[['mesic thermic']] <- list(header="Soil Temperature Regime Uncertainty (Mesic/Thermic)",
+                                   description="Areas with an uncertain soil temperature regime occur where the confidence interval for modeled mean annual soil temperature overlaps mesic/thermic break of 15&deg; C.",
+                                   usage="Use this layer to identify the map units occuring where soil temperature regime cannot be definitively assigned.",
+                                   decimals=2,
+                                   levels = c(1,0), 
+                                   labels = c("uncertain","certain"),
+                                   colors = brewer.pal(3, 'Spectral')[1:2])
+
+categorical.defs[['R105']] <- list(header="R105/106-ness Index",
+                                            description="This layer aggregates slope, curvature and aspect data to determine how many of the required abiotic factor criteria are met for the fire-dominated chaparral ecological sites (18XIR105 and 18XIR106). These two ecological sites differ in climatic characteristics (R105 is mesic to borderline thermic) but both require slopes >30%, convex curvature and south-facing aspect.",
+                                            usage="The numeric values in class names correspond to the number of abiotic factor criteria met (out of a total of 3). At least two of the criteria need to be met in order to support the R105/106 ecosite assignment, which is also based on the soil properties (typically shallower, fraggy/rocky or both) and existing vegetation (chaparral).  The proportions in the bar chart show the relative abundance of samples meeting that number of criteria (ranging from 0 to all 3) for each mapunit. ",
+                                            decimals=2,
+                                            levels = c(0,1,2,3), 
+                                            labels = c("0","1","2","3"),
+                                            colors = brewer.pal(4, 'Spectral'))
+
+### TEMPLATE
+# categorical.defs[['%%%PATTERN%%%']] <- list(header="%%%HEADER%%%",
+#                                    description="%%%DESCRIPTION%%%",  
+#                                    usage="%%%USAGE%%%",
+#                                    levels = %%%LEVELS%%%, 
+#                                    labels = %%%LABELS%%%,
+#                                    colors = %%%COLORS%%%,
+#                                    decimals = %%%DECIMALS%%%)
+## replace %%%PATTERN%%% with a regular expression that uniquely matches the categorical raster dataset name from the config file
+## replace %%%HEADER%%% with the text to be used as header for plot and table in this dataset. will be a 3rd level header (preceded by ###) in markdown
+## replace %%%DESCRIPTION%%% with a text description of the dataset, method used to obtain, label meanings, assumptions, supplemental info/links etc.
+## replace %%%USAGE%%% brief text description of how to interpret/compare the output
+## replace %%%DECIMALS%%% with the number of decimals you would like to truncate table proportions to (default = 2)
+
+##The following three definitions are specified as vectors and are intended to be 1:1 with one another or length 1
+## replace %%%LEVELS%%% numeric vector corresponding to the unique values from raster (e.g. from unique(dat$values))
+## replace %%%LABELS%%% character vector describing the numeric value. order matches the numeric values of LEVELS.
+## replace %%%COLORS%%% character vector hexadecimal or other suitable color specification (e.g. integers, color.brewer()), same order as above
+
+### OPTIONAL
+## NOTE: to add an optional element be sure to add a comma to the categorical metadata definition list
+###
+## keep.all.classes=TRUE 
+##
+#### keep.all.classes will prevent the removal of un-used classes from the legend and tabular output

--- a/inst/reports/region2/mu-comparison/categorical_definitions.R
+++ b/inst/reports/region2/mu-comparison/categorical_definitions.R
@@ -1,0 +1,90 @@
+###TODO: EXTRACT DESCRIPTION FROM XML METADATA OF RASTER?
+
+categorical.defs[['curvature']] <- list(header="Slope Shape (Curvature) Summary",
+                                        # set names: from Field Guide for description of soils
+                                        ## source data: opposite convention
+                                        # 1's place: profile curvature
+                                        # 10's place: plan curvature
+                                        #
+                                        ## adapted from above
+                                        ## data are reported down/across slope
+                                        # L/L | L/V | L/C         22 | 32 | 12  
+                                        # V/L | V/V | V/C   ----> 23 | 33 | 13
+                                        # C/L | C/V | C/C         21 | 31 | 11
+                                        #
+                                        # order according to approximate "shedding" -> "accumulating" gradient:
+                                        # 'V/V', 'L/V', 'V/L', 'C/V', 'LL', 'C/L', 'V/C', 'L/C', 'C/C'
+                                        description="Curvature classes were generated using a 5x5 moving window and a regional 30m or 10m integer DEM. The precision may be limited, so use with caution. See instructions for using your own (higher resolution) curvature classification raster. The conventions used here are \"C\" = concave, \"L\" = linear, and \"V\" = convex; \"down slope\" / \"across slope\". Window size has a significant impact on reported curvature classes; larger windows = more generalization. Curvature class and colors are aligned with an idealized *shedding* &rarr; *accumulating* hydrologic gradient.",
+                                        usage="Use the graphical summary to identify patterns, then consult the tabular representation for specifics.\n* ",
+                                        decimals=2,
+                                        levels = c(33, 32, 23, 31, 22, 21, 13, 12, 11), 
+                                        labels = c('VV', 'LV', 'VL', 'CV', 'LL', 'CL', 'VC', 'LC', 'CC'),
+                                        colors=brewer.pal(9, 'Spectral'),
+                                        keep.all.classes=TRUE)
+
+categorical.defs[['geomorphon']] <- list(header="Geomorphon Landform Classification",
+                                         description="Proportion of samples within each map unit that correspond to 1 of 10 possible landform positions, as generated via [geomorphon](https://grass.osgeo.org/grass70/manuals/addons/r.geomorphon.html) algorithm. Landform classification by [this method](http://dx.doi.org/10.1016/j.geomorph.2012.11.005) is scale-invariant and is therefore not affected by computational window size selection. Landform class labels and colors are aligned with an idealized *shedding* &rarr; *accumulating* hydrologic gradient. \"Flat\" is based on a 3% slope threshold.Map units are organized (in the figure) according to the similarity, computed from proportions of each landform position. The [dendrogram](http://ncss-tech.github.io/stats_for_soil_survey/chapter_5.html) on the right side of the figure describes relative similarity. \"Lower branch height\" (e.g. closer to the right-hand side of the figure) denotes more similar landform positions.",
+                                         usage="Use the graphical summary to identify patterns, then consult the tabular representation for specifics.",
+                                         decimals=2,
+                                         levels=1:10, 
+                                         labels = c('flat', 'summit', 'ridge', 'shoulder', 'spur', 'slope', 'hollow', 'footslope', 'valley', 'depression'),
+                                         colors=c('grey', brewer.pal(9, 'Spectral')),
+                                         keep.all.classes=TRUE)
+
+categorical.defs[['nlcd']] <- list(header="National Land Cover Dataset (NLCD)",
+                                   description="These values are from the [2011 NLCD](https://www.mrlc.gov/nlcd2011.php) (30m) database.",
+                                   usage="Use the graphical summary to identify patterns, then consult the tabular representation for specifics.",
+                                   decimals=2,
+                                   levels = c(0L, 11L, 12L, 21L, 22L, 23L, 24L, 31L, 41L, 42L, 43L, 51L, 52L, 71L, 72L, 73L, 74L, 81L, 82L, 90L, 95L), 
+                                   labels = c("nodata", "Open Water", "Perennial Ice/Snow", "Developed, Open Space", 
+                                              "Developed, Low Intensity", "Developed, Medium Intensity", "Developed, High Intensity", 
+                                              "Barren Land (Rock/Sand/Clay)", "Deciduous Forest", "Evergreen Forest", 
+                                              "Mixed Forest", "Dwarf Scrub", "Shrub/Scrub", "Grassland/Herbaceous", 
+                                              "Sedge/Herbaceous", "Lichens", "Moss", "Pasture/Hay", "Cultivated Crops", 
+                                              "Woody Wetlands", "Emergent Herbaceous Wetlands"),
+                                   colors = c("#000000",  "#476BA0", "#D1DDF9", "#DDC9C9", "#D89382", "#ED0000", "#AA0000", 
+                                              "#B2ADA3", "#68AA63", "#1C6330", "#B5C98E", "#A58C30", "#CCBA7C", 
+                                              "#E2E2C1", "#C9C977", "#99C147", "#77AD93", "#DBD83D", "#AA7028", 
+                                              "#BAD8EA", "#70A3BA"))
+
+categorical.defs[['mesic thermic']] <- list(header="Soil Temperature Regime Uncertainty (Mesic/Thermic)",
+                                   description="Areas with an uncertain soil temperature regime occur where the confidence interval for modeled mean annual soil temperature overlaps mesic/thermic break of 15&deg; C.",
+                                   usage="Use this layer to identify the map units occuring where soil temperature regime cannot be definitively assigned.",
+                                   decimals=2,
+                                   levels = c(1,0), 
+                                   labels = c("uncertain","certain"),
+                                   colors = brewer.pal(3, 'Spectral')[1:2])
+
+categorical.defs[['R105']] <- list(header="R105/106-ness Index",
+                                            description="This layer aggregates slope, curvature and aspect data to determine how many of the required abiotic factor criteria are met for the fire-dominated chaparral ecological sites (18XIR105 and 18XIR106). These two ecological sites differ in climatic characteristics (R105 is mesic to borderline thermic) but both require slopes >30%, convex curvature and south-facing aspect.",
+                                            usage="The numeric values in class names correspond to the number of abiotic factor criteria met (out of a total of 3). At least two of the criteria need to be met in order to support the R105/106 ecosite assignment based on the soil propertiesa (typically shallower, fraggy/rocky or both) and existing vegetation.  The proportions in the bar chart show the relative abundance of samples meeting that number of criteria within each map unit. ",
+                                            decimals=2,
+                                            levels = c(0,1,2,3), 
+                                            labels = c("0","1","2","3"),
+                                            colors = brewer.pal(4, 'Spectral'))
+
+### TEMPLATE
+# categorical.defs[['%%%PATTERN%%%']] <- list(header="%%%HEADER%%%",
+#                                    description="%%%DESCRIPTION%%%",  
+#                                    usage="%%%USAGE%%%",
+#                                    levels = %%%LEVELS%%%, 
+#                                    labels = %%%LABELS%%%,
+#                                    colors = %%%COLORS%%%,
+#                                    decimals = %%%DECIMALS%%%)
+## replace %%%PATTERN%%% with a regular expression that uniquely matches the categorical raster dataset name from the config file
+## replace %%%HEADER%%% with the text to be used as header for plot and table in this dataset. will be a 3rd level header (preceded by ###) in markdown
+## replace %%%DESCRIPTION%%% with a text description of the dataset, method used to obtain, label meanings, assumptions, supplemental info/links etc.
+## replace %%%USAGE%%% brief text description of how to interpret/compare the output
+## replace %%%DECIMALS%%% with the number of decimals you would like to truncate table proportions to (default = 2)
+
+##The following three definitions are specified as vectors and are intended to be 1:1 with one another or length 1
+## replace %%%LEVELS%%% numeric vector corresponding to the unique values from raster (e.g. from unique(dat$values))
+## replace %%%LABELS%%% character vector describing the numeric value. order matches the numeric values of LEVELS.
+## replace %%%COLORS%%% character vector hexadecimal or other suitable color specification (e.g. integers, color.brewer()), same order as above
+
+### OPTIONAL
+## NOTE: to add an optional element be sure to add a comma to the categorical metadata definition list
+###
+## keep.all.classes=TRUE 
+##
+#### keep.all.classes will prevent the removal of un-used classes from the legend and tabular output

--- a/inst/reports/region2/mu-comparison/changes.txt
+++ b/inst/reports/region2/mu-comparison/changes.txt
@@ -1,3 +1,4 @@
+2017-06-23 (2.6): procedural generation of markdown for arbitrary categoricals; created highly customizable categorical definitions file and moved custom report functions to separate file for upcoming soilReport manifest update;
 2017-06-07: (2.5): bug fixes related to specification of a single raster input; dynamic heights for bwplot and density plots
 2017-04-05 (2.3): minor additions, as suggested by folks on 4/13 and 4/14 teleconferences, simple fix for MU specified in config.R and not in MU polys
 2017-04-05 (2.2): new approach for normalization of y-axis of density estimates, addressing (https://github.com/ncss-tech/soilReports/issues/39)

--- a/inst/reports/region2/mu-comparison/config.R
+++ b/inst/reports/region2/mu-comparison/config.R
@@ -5,7 +5,6 @@
 ### configuration file, edit as needed
 ###
 
-
 #########################
 ### Raster Data Sources #
 #########################
@@ -16,28 +15,32 @@
 
 raster.list <- list(
   continuous=list(
-    `Mean Annual Air Temperature (degrees C)`='E:/Workspace/geodata/PRISM_800m/final_MAAT_800m.tif', 
-    `Mean Annual Precipitation (mm)`='E:/Workspace/geodata/PRISM_800m/final_MAP_mm_800m.tif',
-    `Effective Precipitation (mm)`='E:/Workspace/geodata/PRISM_800m/effective_precipitation_800m.tif',
-    `Frost-Free Days`='E:/Workspace/geodata/PRISM_800m/ffd_mean_800m.tif',
-    `Growing Degree Days (degrees C)`='E:/Workspace/geodata/PRISM_800m/gdd_mean_800m.tif',
-    `Elevation (m)`='E:/Workspace/geodata/DEM_KLM_int_AEA.tif',
-    `Slope Gradient (%)`='E:/Workspace/geodata/Slope_KLM_int_AEA.tif'
-    #`Annual Beam Radiance (MJ/sq.m)`='E:/gis_data/ca630/beam_rad_sum_mj_30m.tif,
-    #`(Estimated) MAST (degrees C)`='E:/gis_data/ca630/mast-model.tif'
-    # `Compound Topographic Index`='E:/gis_data/ca630/tci30.tif',
-    # `MRVBF`='E:/gis_data/ca630/mrvbf_10.tif',
-    # `SAGA TWI`='E:/gis_data/ca630/saga_twi_10.tif'
+    `Mean Annual Air Temperature (degrees C)`='L:/NRCS/MLRAShared/Geodata/climate/raster/final_MAAT_800m.tif', 
+    `Mean Annual Precipitation (mm)`='L:/NRCS/MLRAShared/Geodata/climate/raster/final_MAP_mm_800m.tif', 
+    `Effective Precipitation (mm)`='L:/NRCS/MLRAShared/Geodata/climate/raster/effective_precipitation_800m.tif',
+    `Frost-Free Days`='L:/NRCS/MLRAShared/Geodata/climate/raster/ffd_mean_800m.tif',
+    `Growing Degree Days (degrees C)`='L:/NRCS/MLRAShared/Geodata/climate/raster/gdd_mean_800m.tif',
+    `Elevation (m)`='L:/NRCS/MLRAShared/Geodata/elevation/10_meter/ca630_elev',
+    `Slope Gradient (%)`='L:/NRCS/MLRAShared/Geodata/elevation/10_meter/ca630_slope',
+    `Rain Fraction`='L:/NRCS/MLRAShared/Geodata/climate/raster/rain_fraction_mean_800m.tif',
+    `Annual Beam Radiance (MJ/sq.m)`='L:/NRCS/MLRAShared/Geodata/DEM_derived/beam_rad_sum_mj_30m.tif',
+    `(Estimated) MAST (degrees C)`='E:/geodata/ca630/soil_temperature/spatial_data/mast-model.tif',
+    `Compound Topographic Index`='L:/NRCS/MLRAShared/Geodata/DEM_derived/tci30.tif',
+    `SAGA TWI`='L:/NRCS/MLRAShared/Geodata/DEM_derived/saga_twi_10.tif',
+    `K40 percentage`='L:/NRCS/MLRAShared/Geodata/Radiometric/namrad_k_aea.tif'
   ),
   categorical=list(
-    `Geomorphon Landforms`='E:/Workspace/geodata/Geomorphons/forms10_region2.tif',
-    `Curvature Classes`='E:/Workspace/geodata/MU_Curvature/curvature_classes_10_class_region2.tif',
-    `NLCD 2011`='E:/Workspace/geodata/land_use_land_cover/nlcd_2011_cropped.tif'
+    `R1056ness`='E:/workspace/r1056ness_ras',
+    `Geomorphon Landforms`='L:/NRCS/MLRAShared/Geodata/DEM_derived/forms10.tif',
+    `Curvature Classes`='L:/NRCS/MLRAShared/Geodata/DEM_derived/curvature_classes_15.tif',
+    `NLCD`='L:/NRCS/MLRAShared/Geodata/NLCD/nlcd_ca630',
+    `Mesic Thermic Uncertainty`='S:/NRCS/Archive_Dylan_Beaudette/CA630-models/hobo_soil_temperature/spatial_data/mast-model-mesic_thermic-uncertainty.tif'
   ),
   circular=list(
-    `Slope Aspect (degrees)`='E:/Workspace/geodata/Aspect_KLM_int_AEACopy.tif'
-    )
+    `Slope Aspect (degrees)`='L:/NRCS/MLRAShared/Geodata/DEM_derived/ca630_aspect'
+  )
 )
+
 
 
 ###################
@@ -58,7 +61,7 @@ raster.list <- list(
 # name of featureclass
 # mu.layer <- 'ca630_a'
 # map unit symbols / keys to extract
-# mu.set <- c('7011', '5012', '7089')
+ mu.set <- c('6072','6071','6205','6034')
 
 
 
@@ -67,9 +70,9 @@ raster.list <- list(
 ##
 
 # path to SHP
-mu.dsn <- 'E:/Workspace/Project_Folder/MUSum'
+mu.dsn <- 'L:/NRCS/MLRAShared/CA630/FG_CA630_OFFICIAL.gdb'
 # SHP name, without file extension
-mu.layer <- 'MUs_for_analysis'
+mu.layer <- 'ca630_a'
  
 
 
@@ -89,7 +92,7 @@ mu.col <- 'MUSYM'
 # increase if there are un-sampled polygons
 # delineations smaller than 5 ac. may require up to 5 points / ac.
 # values > 6-7 points / ac. will only slow things down
-pts.per.acre <- 1
+pts.per.acre <- 0.01
 
 
 

--- a/inst/reports/region2/mu-comparison/custom.R
+++ b/inst/reports/region2/mu-comparison/custom.R
@@ -1,0 +1,220 @@
+#Mapunit summary utility functions
+
+# remove NA from $value
+# compute density for $value, using 1.5x "default" bandwidth
+# re-scale to {0,1}
+# return x,y values
+scaled.density <- function(d) {
+  res <- stats::density(na.omit(d$value), kernel='gaussian', adjust=1.5)
+  return(data.frame(x=res$x, y=scales::rescale(res$y)))
+}
+
+#TODO: this could be useful in soilReports? not really sharpshootR worthy since it has nothing to do with soil... might be best just left here
+# abstracted this for use in the default symbology for "undefined" categoricals, made a call for the old use of defining mapunit colors for legends
+makeNiceColors <- function(n) {
+  if(n <= 7) {# 7 or fewer classes, use high-constrast colors
+    cols <- brewer.pal(9, 'Set1') 
+    # remove light colors
+    cols <- cols[c(1:5,7,9)]
+  } else {
+    # otherwise, use 12 paired colors
+    cols <- brewer.pal(12, 'Paired')
+  }
+  return(cols[1:n])
+}
+
+abbreviateNames <- function(spdf) {
+  sapply(names(spdf)[-1], function(i) {
+    # keep only alpha and underscore characters in field names
+    i <- gsub('[^[:alpha:]_]', '', i)
+    # abbreviate after filtering other bad chars
+    abbr <- abbreviate(i, minlength = 10)
+    return(abbr)
+  })
+}
+
+# return DF with proportions outside range for each polygon (by pID)
+flagPolygons <- function(i) {
+  
+  # convert to values -> quantiles
+  e.i <- ecdf(i$value)
+  q.i <- e.i(i$value)
+  # locate those samples outside of our 5th-95th range
+  out.idx <- which(q.i < 0.05 | q.i > 0.95)
+  
+  ## TODO: may need to protect against no matching rows?
+  tab <- sort(prop.table(table(i$pID[out.idx])), decreasing = TRUE)
+  df <- data.frame(pID=names(tab), prop.outside.range=round(as.vector(tab), 2))
+  
+  # keep only those with > 15% of samples outside of range
+  #df <- df[which(df$prop.outside.range > p.crit), ]  
+  
+  #all proportions outside now reported in QC shapefile; no need to have a threshold
+  return(df)
+}
+
+
+# http://stackoverflow.com/questions/16225530/contours-of-percentiles-on-level-plot
+kdeContours <- function(i, prob, cols, m, ...) {
+  
+  if(nrow(i) < 2) {
+    return(NULL)
+  }
+  
+  this.id <- unique(i$.id)
+  this.col <- cols[match(this.id, m)]
+  dens <- kde2d(i$x, i$y, n=200); ## estimate the z counts
+  
+  dx <- diff(dens$x[1:2])
+  dy <- diff(dens$y[1:2])
+  sz <- sort(dens$z)
+  c1 <- cumsum(sz) * dx * dy
+  levels <- sapply(prob, function(x) {
+    approx(c1, sz, xout = 1 - x)$y
+  })
+  
+  # add contours if possibly
+  if(!is.na(levels))
+    contour(dens, levels=levels, drawlabels=FALSE, add=TRUE, col=this.col, ...)
+  
+  # # add bivariate medians
+  # points(median(i$x), median(i$y), pch=3, lwd=2, col=this.col)
+}
+
+
+# masking function applied to a "wide" data.frame of sampled raster data
+# function is applied column-wise
+# note: using \leq and \geq for cases with very narrow distributions
+mask.fun <- function(i) {
+  res <- i >= quantile(i, prob=0.05, na.rm=TRUE) & i <= quantile(i, prob=0.95, na.rm=TRUE)
+  return(res)
+}
+
+
+# cut down to reasonable size: using cLHS
+f.subset <- function(i, n, non.id.vars) {
+  # if there are more than n records, then sub-sample
+  if(nrow(i) > n) {
+    # columns with IDs have been pre-filtered
+    idx <- clhs(i[, non.id.vars], size=n, progress=FALSE, simple=TRUE, iter=1000)
+    i.sub <- i[idx, ]
+  }
+  #	otherwise use what we have
+  else
+    i.sub <- i
+  
+  return(i.sub)
+}
+
+
+# set multi-row figure based on number of groups and fixed number of columns
+dynamicPar <- function(n, max.cols=3) {
+  # simplest case, fewer than max number of allowed columns
+  if(n <= max.cols) {
+    n.rows <- 1
+    n.cols <- n
+  } else {
+    
+    # simplest case, a square
+    if(n %% max.cols == 0) {
+      n.rows <- n / max.cols
+      n.cols <- max.cols
+    } else {
+      # ragged
+      n.rows <- round(n / max.cols) + 1
+      n.cols <- max.cols
+    }
+  }
+  
+  par(mar=c(0,0,0,0), mfrow=c(n.rows, n.cols))
+  # invisibly return geometry
+  invisible(c(n.rows, n.cols))
+}
+
+# stat summary function
+f.summary <- function(i, p) {
+  
+  # remove NA
+  v <- na.omit(i$value)
+  
+  # compute quantiles
+  q <- quantile(v, probs=p)
+  res <- data.frame(t(q))
+  
+  ## TODO: implement better MADM processing and explanation  
+  if(nrow(res) > 0) {
+    #     # MADM: MAD / median
+    #     # take the natural log of absolute values of MADM
+    #     res$log_abs_madm <- log(abs(mad(v) / median(v)))
+    #     # 0's become -Inf: convert to 0
+    #     res$log_abs_madm[which(is.infinite(res$log_abs_madm))] <- 0
+    
+    # assign reasonable names (quantiles)
+    names(res) <- c(paste0('Q', p * 100))
+    
+    return(res)
+  }
+  else
+    return(NULL)
+}
+
+# custom stats for box-whisker plot: 5th-25th-50th-75th-95th percentiles
+# NOTE: we are re-purposing the coef argument!
+# x: vector of values to summarize
+# coef: Moran's I associated with the current raster
+custom.bwplot <- function(x, coef=NA, do.out=FALSE) {
+  # custom quantiles for bwplot
+  stats <- quantile(x, p=c(0.05, 0.25, 0.5, 0.75, 0.95), na.rm = TRUE)
+  # number of samples
+  n <- length(na.omit(x))
+  
+  # compute effective sample size
+  rho <- coef
+  n_eff <- ESS_by_Moran_I(n, rho)
+  
+  # confidence "notch" is based on ESS
+  iqr <- stats[4] - stats[2]
+  conf <- stats[3] + c(-1.58, 1.58) * iqr/sqrt(n_eff)
+  
+  out.low <- x[which(x < stats[1])]
+  out.high <- x[which(x > stats[5])]
+  
+  return(list(stats=stats, n=n, conf=conf, out=c(out.low, out.high)))
+}
+
+
+#####
+## Functions for manipulating categorical variable set
+#TODO: these are connotative but somewhat confusingly named... refactor eventually. all basicalyl internal stuff so not a huge issue.
+# Functions for use in dealing with arbitrary categoricals, categorical symbology and toggling of sections when new categoricals are added
+variableNameFromPattern <-  function (pattern) {
+  unique(d.cat$variable)[grep(pattern, unique(d.cat$variable), ignore.case = TRUE)]
+}
+
+variableNameToPattern <- function(name) {
+  patterns = names(categorical.defs)
+  for(p in patterns)
+    if(grepl(p, name, ignore.case = TRUE)) return(p)
+  return(NULL)
+}
+
+categoricalVariableHasDefinition <- function(variable.name) {
+  if(sum(names(categorical.defs) %in% variable.name) > 0) return(TRUE)
+  return(FALSE)
+}
+
+subsetByName <- function(name) {
+  return(subset(d.cat, subset=(variable == name)))
+}
+
+subsetByPattern <- function(pattern) {
+  subsetByName(getCategoricalVariableNameFromPattern(pattern))
+}
+
+sweepProportions <- function(i,drop.unused.levels=F) {
+  # tabulate and convert to proportions, retain all levels of ID
+  i$.id <- factor(i$.id)
+  foo <- xtabs(~ .id + value, data=i, drop.unused.levels=drop.unused.levels)
+  return(sweep(foo, MARGIN = 1, STATS = rowSums(foo), FUN = '/'))
+}
+

--- a/inst/reports/region2/mu-comparison/report.Rmd
+++ b/inst/reports/region2/mu-comparison/report.Rmd
@@ -1,23 +1,17 @@
 ---
 title: null
-output:
-  html_document:
-    mathjax: null
-    jquery: null
-    smart: no
-    keep_md: no
+output: html_document
 ---
 
 ```{r report-metadata, echo=FALSE, results='hide', warning=FALSE, message=FALSE}
 ## version number
-.report.version <- '2.5'
+.report.version <- '3.0'
 
 ## short description
 .report.description <- 'compare stack of raster data, sampled from polygons associated with 1-8 map units'
 ```
 
 ```{r setup, echo=FALSE, results='hide', warning=FALSE, message=FALSE}
-# setup
 library(knitr, quietly=TRUE)
 
 # package options
@@ -29,179 +23,11 @@ opts_chunk$set(message=FALSE, warning=FALSE, background='#F7F7F7', fig.align='ce
 # R session options
 options(width=100, stringsAsFactors=FALSE)
 
+## load dependencies
 
-## custom functions
+#TODO: verify that these have been installed and correct version. Just as a sanity check, should check version being compatible with report manifest
+# reportSetup should do this on creation of the report instance (see soilReports issue #45 on GH)
 
-# remove NA from $value
-# compute density for $value, using 1.5x "default" bandwidth
-# re-scale to {0,1}
-# return x,y values
-scaled.density <- function(d) {
-  res <- stats::density(na.omit(d$value), kernel='gaussian', adjust=1.5)
-  return(data.frame(x=res$x, y=scales::rescale(res$y)))
-}
-
-
-abbreviateNames <- function(spdf) {
- sapply(names(spdf)[-1], function(i) {
-  # keep only alpha and underscore characters in field names
-  i <- gsub('[^[:alpha:]_]', '', i)
-  # abbreviate after filtering other bad chars
-  abbr <- abbreviate(i, minlength = 10)
-  return(abbr)
-  })
-}
-
-# return DF with proportions outside range for each polygon (by pID)
-flagPolygons <- function(i) {
-  
-   # convert to values -> quantiles
-  e.i <- ecdf(i$value)
-  q.i <- e.i(i$value)
-  # locate those samples outside of our 5th-95th range
-  out.idx <- which(q.i < 0.05 | q.i > 0.95)
-  
-  ## TODO: may need to protect against no matching rows?
-  tab <- sort(prop.table(table(i$pID[out.idx])), decreasing = TRUE)
-  df <- data.frame(pID=names(tab), prop.outside.range=round(as.vector(tab), 2))
-  
-  # keep only those with > 15% of samples outside of range
-  #df <- df[which(df$prop.outside.range > p.crit), ]  
-  
-  #all proportions outside now reported in QC shapefile; no need to have a threshold
-  return(df)
-}
-
-
-# http://stackoverflow.com/questions/16225530/contours-of-percentiles-on-level-plot
-kdeContours <- function(i, prob, cols, m, ...) {
-  
-  if(nrow(i) < 2) {
-    return(NULL)
-  }
-  
-  this.id <- unique(i$.id)
-  this.col <- cols[match(this.id, m)]
-  dens <- kde2d(i$x, i$y, n=200); ## estimate the z counts
-
-  dx <- diff(dens$x[1:2])
-  dy <- diff(dens$y[1:2])
-  sz <- sort(dens$z)
-  c1 <- cumsum(sz) * dx * dy
-  levels <- sapply(prob, function(x) {
-    approx(c1, sz, xout = 1 - x)$y
-  })
-  
-  # add contours if possibly
-  if(!is.na(levels))
-    contour(dens, levels=levels, drawlabels=FALSE, add=TRUE, col=this.col, ...)
-  
-  # # add bivariate medians
-  # points(median(i$x), median(i$y), pch=3, lwd=2, col=this.col)
-}
-
-
-# masking function applied to a "wide" data.frame of sampled raster data
-# function is applied column-wise
-# note: using \leq and \geq for cases with very narrow distributions
-mask.fun <- function(i) {
-  res <- i >= quantile(i, prob=0.05, na.rm=TRUE) & i <= quantile(i, prob=0.95, na.rm=TRUE)
-  return(res)
-}
-
-
-# cut down to reasonable size: using cLHS
-f.subset <- function(i, n, non.id.vars) {
-	# if there are more than n records, then sub-sample
-	if(nrow(i) > n) {
-	  # columns with IDs have been pre-filtered
-		idx <- clhs(i[, non.id.vars], size=n, progress=FALSE, simple=TRUE, iter=1000)
-		i.sub <- i[idx, ]
-	}
-	#	otherwise use what we have
-	else
-		i.sub <- i
-	
-	return(i.sub)
-}
-
-
-# set multi-row figure based on number of groups and fixed number of columns
-dynamicPar <- function(n, max.cols=3) {
-  # simplest case, fewer than max number of allowed columns
-  if(n <= max.cols) {
-    n.rows <- 1
-    n.cols <- n
-  } else {
-    
-    # simplest case, a square
-    if(n %% max.cols == 0) {
-      n.rows <- n / max.cols
-      n.cols <- max.cols
-    } else {
-      # ragged
-      n.rows <- round(n / max.cols) + 1
-      n.cols <- max.cols
-    }
-  }
-  
-  par(mar=c(0,0,0,0), mfrow=c(n.rows, n.cols))
-  # invisibly return geometry
-  invisible(c(n.rows, n.cols))
-}
-
-# stat summary function
-f.summary <- function(i, p) {
-  
-  # remove NA
-  v <- na.omit(i$value)
-  
-  # compute quantiles
-  q <- quantile(v, probs=p)
-  res <- data.frame(t(q))
-  
-  ## TODO: implement better MADM processing and explanation  
-  if(nrow(res) > 0) {
-#     # MADM: MAD / median
-#     # take the natural log of absolute values of MADM
-#     res$log_abs_madm <- log(abs(mad(v) / median(v)))
-#     # 0's become -Inf: convert to 0
-#     res$log_abs_madm[which(is.infinite(res$log_abs_madm))] <- 0
-    
-    # assign reasonable names (quantiles)
-    names(res) <- c(paste0('Q', p * 100))
-    
-    return(res)
-  }
-  else
-    return(NULL)
-}
-
-# custom stats for box-whisker plot: 5th-25th-50th-75th-95th percentiles
-# NOTE: we are re-purposing the coef argument!
-# x: vector of values to summarize
-# coef: Moran's I associated with the current raster
-custom.bwplot <- function(x, coef=NA, do.out=FALSE) {
-  # custom quantiles for bwplot
-  stats <- quantile(x, p=c(0.05, 0.25, 0.5, 0.75, 0.95), na.rm = TRUE)
-  # number of samples
-  n <- length(na.omit(x))
-  
-  # compute effective sample size
-  rho <- coef
-  n_eff <- ESS_by_Moran_I(n, rho)
-  
-  # confidence "notch" is based on ESS
-  iqr <- stats[4] - stats[2]
-  conf <- stats[3] + c(-1.58, 1.58) * iqr/sqrt(n_eff)
-  
-  out.low <- x[which(x < stats[1])]
-  out.high <- x[which(x > stats[5])]
-  
-  return(list(stats=stats, n=n, conf=conf, out=c(out.low, out.high)))
-}
-
-# load required packages
 library(MASS, quietly=TRUE)
 library(rgdal, quietly=TRUE)
 library(rgeos, quietly=TRUE)
@@ -215,58 +41,44 @@ library(clhs, quietly=TRUE)
 library(randomForest, quietly=TRUE)
 library(spdep, quietly=TRUE)
 
+## load report-specific functions
+source('custom.R') 
 
-## load local configuration
+## load local configuration 
+#TODO: allow entry of simple fields interactively if they are not specified?
+#TODO: allow for batching from a basic report.Rmd
 source('config.R')
-```
 
-
-```{r, echo=FALSE, results='hide'}
-# load map unit polygons from OGR data source
+## load map unit polygons from OGR data source
 mu <- try(readOGR(dsn=mu.dsn, layer=mu.layer, stringsAsFactors = FALSE))
 if(class(mu) == 'try-error')
   stop(paste0('Cannot find map unit polygon file/feature: "', mu.dsn, ' / ', mu.layer, '"'), call. = FALSE)
 
-# just in case, coerce mu.col to character
-mu[[mu.col]] <- as.character(mu[[mu.col]])
+mu[[mu.col]] <- as.character(mu[[mu.col]]) # just in case, coerce mu.col to character
 
 # if no filter, then keep all map units
-if(exists('mu.set')) {
+if(exists('mu.set')) { #TODO: this type of if(exists(obj)) needs to wrap all references to report parameters 
   # coerce mu.set to character just in integers were specified
   mu.set <- as.character(mu.set)
-  # filter
-  mu <- mu[which(mu[[mu.col]] %in% mu.set), ]
-  # just in case an MU is specified that doesn't exist, 
-  # keep only those records that made it through the filering step
-  mu.set <- unique(mu[[mu.col]])
-} else {
-  # mu.set not defined in config.R, define using the data on hand
-  mu.set <- unique(mu[[mu.col]])
+  mu <- mu[which(mu[[mu.col]] %in% mu.set), ] # if mu.set defined in config.R, only keep the items from set
 }
-
-# nice colors
-# 7 or fewer classes, use high-constrast colors
-if(length(mu.set) <= 7) {
-  cols <- brewer.pal(9, 'Set1') 
-  # remove light colors
-  cols <- cols[c(1:5,7,9)]
-} else {
-  # otherwise, use 12 paired colors
-  cols <- brewer.pal(12, 'Paired')
-}
+#mu.set <- unique(mu[[mu.col]])# keep only those records that made it through the filering step
 
 # add a unique polygon ID
 mu$pID <- seq(from=1, to=length(mu))
 
-# check for cached data
 if(cache.samples & file.exists('cached-samples.Rda')) {
   message('Using cached raster samples...')
   .sampling.time <- 'using cached samples'
   load('cached-samples.Rda')
 } else {
+  #This script generates an Rda file (R object) containing samples from a set of rasters overlapping a polygon feature class.
+  #Samples are obtained from features of interest using constant density sampling. These data can then be used for summary of the variable space associated with mapunits, geologies, MLRAs, study areas, etc. Several reports have been designed to make use of these datasets. 
   
-  # remove previous samples
-  unlink('cached-samples.Rda')
+  #TODO: check for existence of parameter objects before using them... fail elegantly by asking for user input via knitr?
+  # Sourcing this script succesfully relies on a baseline definition of report parameters in the global environment. 
+  # Needed params and names are based on config.R from v2.5 of mu summary report, though they may be defined in any way that is convenient
+  # (i.e. batch/programattically, interactively, and via static config file)
   
   # suppressing warnings: these have to do with conversion of CRS of points
   # iterate over map units and sample rasters
@@ -274,60 +86,41 @@ if(cache.samples & file.exists('cached-samples.Rda')) {
   .timer.start <- Sys.time()
   sampling.res <- suppressWarnings(sampleRasterStackByMU(mu, mu.set, mu.col, raster.list, pts.per.acre, estimateEffectiveSampleSize = correct.sample.size))
   .timer.stop <- Sys.time()
+  
   .sampling.time <- format(difftime(.timer.stop, .timer.start, units='mins'), digits=2)
-
-  # cache for later
+  print(paste0("Completed sampling of raster stack for poly symbols (",paste(mu.set,collapse=","),") in ",.sampling.time,"."))
+  
+  sampling.res$raster.samples$.id <- factor(sampling.res$raster.samples$.id, levels=mu.set)
+  #TODO: toggle for appending date/time to file name for Rda containing samnples; or take file name as param?
+  save(sampling.res, file=paste0("samples_",paste(mu.set,collapse="_"),"-",strftime(Sys.time(),format="%Y%m%d_%H%M%S"),".Rda"))
+  print("DONE!")
+  
   if(cache.samples)
-    save(sampling.res, file='cached-samples.Rda')
+    save(mu, sampling.res,file = 'cached-samples.Rda')
 }
 
-## convert MU id into factor, using originally specified levels
-sampling.res$raster.samples$.id <- factor(sampling.res$raster.samples$.id, levels=mu.set)
-
-## split raster data into types: continuous, categorical, circular
-d.cat <- subset(sampling.res$raster.samples, variable.type == 'categorical')
-
-## TODO: could there ever be more than one type of circular variable?
+## subset raster samples by data type: continuous, categorical, circular
+d.continuous <- subset(sampling.res$raster.samples, variable.type == 'continuous')
+d.continuous$variable <- factor(d.continuous$variable, levels=names(raster.list$continuous))
 d.circ <- subset(sampling.res$raster.samples, variable.type == 'circular')
 
-## extract continuous raster values
-d.continuous <- subset(sampling.res$raster.samples, variable.type == 'continuous')
-
-# convert "variable" into a factor with the same order as listed in config.R
-d.continuous$variable <- factor(d.continuous$variable, levels=names(raster.list$continuous))
-
-## http://adv-r.had.co.nz/memory.html#memory
-# free-up some memory
-sampling.res$raster.samples <- NULL
-
-## TODO: eventually there should be a function / template for any categorical data
-
 # subset and enable aspect summary
-if(nrow(d.circ) > 0) {
+if(nrow(d.circ) > 0) { ## TODO: could there ever be more than one type of circular variable? 
+#AB: direction of gradient could be determined for basically any raster... but obv. we don't use anything other than direction of slope gradient
   do.aspect <- TRUE
 } else do.aspect <- FALSE
 
-# subset and enable curvature classes
-curvature.classes <- unique(d.cat$variable)[grep('curvature', unique(d.cat$variable), ignore.case = TRUE)]
-if(length(curvature.classes) > 0) {
-  do.curvature.classes <- TRUE
-  d.curvature.classes <- subset(d.cat, subset=variable == curvature.classes)
-} else do.curvature.classes <- FALSE
+### SUBSET CATEGORICAL VARIABLEs
+#d.cat is derived from the sample object resulting from running cLHS_sample_by_polygon.R
+d.cat <- subset(sampling.res$raster.samples, variable.type == 'categorical')
+d.cat$.id <- factor(d.cat$.id,levels=mu.set)
+d.cat.sub <- list()
+categorical.defs <- list()#this defines the aliases and label:value:color sets for displaying categorical variables
+source("categorical_definitions.R") #this will load the structures that define value:label:color for categorical plot. 
+                                    #updates the "section_toggle" variable defined at top of report which will knit the appropriate plots for the specified categoricals from config.R
 
-# subset and enable geomorphons
-geomorphons.vars <- unique(d.cat$variable)[grep('geomorphon', unique(d.cat$variable), ignore.case = TRUE)]
-if(length(geomorphons.vars) > 0) {
-  do.geomorphons <- TRUE
-  d.geomorphons <- subset(d.cat, subset=variable == geomorphons.vars)
-} else do.geomorphons <- FALSE
 
-# subset and enable 2011 NLCD
-nlcd.classes <- unique(d.cat$variable)[grep('nlcd',unique(d.cat$variable), ignore.case = TRUE)]
-if(length(nlcd.classes) > 0) {
-  do.nlcd.classes <- TRUE
-  d.nlcd.classes <- subset(d.cat, subset=variable == nlcd.classes)
-} else do.nlcd.classes <- FALSE
-
+### FORMATTING
 ## figure out reasonable figure heights for bwplots and density plots
 # baseline height for figure margins, axes, and legend
 min.height <- 2 
@@ -335,9 +128,14 @@ min.height <- 2
 panel.height <- 2 * length(levels(d.continuous$variable))
 # extra height for each ID
 id.height <- 0.25 * length(levels(d.continuous$.id))
-
 dynamic.fig.height <- min.height + panel.height + id.height
 
+# nice colors
+cols <- brewer.pal(length(mu.set), 'Spectral')#makeNiceColors()
+
+#TODO: Null out raster samples to save memory TOGGLE
+## http://adv-r.had.co.nz/memory.html#memory
+#sampling.res$raster.samples <- NULL
 ```
 
 <br>
@@ -349,8 +147,6 @@ report version `r .report.version`
 
 <br>
 This report is designed to provide statistical summaries of the environmental properties for one or more map units. Summaries are based on raster data extracted from [fixed-density sampling of map unit polygons](http://ncss-tech.github.io/AQP/sharpshootR/sample-vs-population.html). [Percentiles](https://ncss-tech.github.io/soil-range-in-characteristics/why-percentiles.html) are used as robust metrics of distribution central tendency and spread. Please see the document titled *R-Based Map Unit Summary Report Introduction and Description* for background and setup.
-
-
 
 ### Map Unit Polygon Data Source
 ```{r, echo=FALSE}
@@ -368,8 +164,6 @@ Target sampling density: <b>`r pts.per.acre` points/ac.</b> defined in `config.R
 ```{r, echo=FALSE}
 kable(sampling.res$area.stats, caption='Map Unit Acreage by Polygon', align = 'r', col.names=c(mu.col, names(sampling.res$area.stats)[-1]))
 ```
-
-
 
 
 ### Modified Box and Whisker Plots
@@ -501,225 +295,132 @@ res <- ldply(d.circ.list, function(i) {
 kable(res, align = 'r', col.names=c(mu.col, names(res)[-1]))
 ```
 
-
-### Slope Shape (Curvature) Summary
-The classes were generated using a 5x5 moving window, from a regional 30m or 10m, integer DEM. The precision may be limited, use with caution. See instructions for using your own (higher resolution) curvature classification raster.
-
-**Suggested usage:**
-
- * Use the graphical summary to identify patterns, then consult the tabular representation for specifics.
- * The conventions used here are "C" = concave, "L" = linear, and "V" = convex; "down slope" / "across slope".
- * Window size has a significant impact on reported curvature classes; larger windows = more generalization.
- * Curvature class and colors are aligned with an idealized *shedding* &rarr; *accumulating* hydrologic gradient.
-
-```{r, echo=FALSE, fig.width=12, fig.height=6, eval=do.curvature.classes}
-# set names: from Field Guide for description of soils
-## source data: opposite convention
-# 1's place: profile curvature
-# 10's place: plan curvature
-#
-## adapted from above
-## data are reported down/across slope
-# L/L | L/V | L/C         22 | 32 | 12  
-# V/L | V/V | V/C   ----> 23 | 33 | 13
-# C/L | C/V | C/C         21 | 31 | 11
-#
-# order according to approximate "shedding" -> "accumulating" gradient:
-# 'V/V', 'L/V', 'V/L', 'C/V', 'LL', 'C/L', 'V/C', 'L/C', 'C/C'
-#
-d.curvature.classes$value <- factor(d.curvature.classes$value, 
-                                    levels=c(33, 32, 23, 31, 22, 21, 13, 12, 11), 
-                                    labels = c('V/V', 'L/V', 'V/L', 'C/V', 'LL', 'C/L', 'V/C', 'L/C', 'C/C'))
-
-# tabulate and convert to proportions
-x <- xtabs(~ .id + value, data=d.curvature.classes)
-x <- sweep(x, MARGIN = 1, STATS = rowSums(x), FUN = '/')
-
-# convert to long format for plotting
-x.long <- melt(x)
-# fix names: second column contains curvature class labels
-names(x.long)[2] <- 'curvature.class'
-
-# make some colors, and set style
-cols.curvature.classes <- brewer.pal(9, 'Spectral')
-tps <- list(superpose.polygon=list(col=cols.curvature.classes, lwd=2, lend=2))
-
-# no re-ordering of musym
-trellis.par.set(tps)
-barchart(as.character(.id) ~ value, groups=curvature.class, data=x.long, horiz=TRUE, stack=TRUE, xlab='Proportion of Samples', scales=list(cex=1.5), key=simpleKey(space='top', columns=3, text=levels(x.long$curvature.class), rectangles = TRUE, points=FALSE))
-```
-
-```{r, echo=FALSE, eval=do.curvature.classes}
-# print and truncate to 2 decimal places
-kable(x, digits = 2, caption = '')
-```
-
-
-
-### Geomorphon Landform Classification
-Proportion of samples within each map unit that correspond to 1 of 10 possible landform positions, as generated via [geomorphon](https://grass.osgeo.org/grass70/manuals/addons/r.geomorphon.html) algorithm. Landform classification by [this method](http://dx.doi.org/10.1016/j.geomorph.2012.11.005) is scale-invariant and is therefore not affected by computational window size selection.
-
-
-**Suggested usage:**
-
-  * Use the graphical summary to identify patterns, then consult the tabular representation for specifics.
-  * "Flat" is based on a 3% slope threshold.
-  * Map units are organized (in the figure) according to the similarity, computed from proportions of each landform position.
-  * The [dendrogram](http://ncss-tech.github.io/stats_for_soil_survey/chapter_5.html) on the right side of the figure describes relative similarity. "Lower branch height" (e.g. closer to the right-hand side of the figure) denotes more similar landform positions.
-  * Landform class labels and colors are aligned with an idealized *shedding* &rarr; *accumulating* hydrologic gradient.
-
-```{r, echo=FALSE, eval=do.geomorphons, fig.width=12, fig.height=6}
-## geomorphons:
-# set names
-# https://grass.osgeo.org/grass70/manuals/addons/r.geomorphon.html
-d.geomorphons$value <- factor(d.geomorphons$value, levels=1:10, labels = c('flat', 'summit', 'ridge', 'shoulder', 'spur', 'slope', 'hollow', 'footslope', 'valley', 'depression'))
-
-# tabulate and convert to proportions
-x <- xtabs(~ .id + value, data=d.geomorphons)
-x <- sweep(x, MARGIN = 1, STATS = rowSums(x), FUN = '/')
-
-# create a signature of the most frequent classes that sum to 75% or
-x.sig <- apply(x, 1, function(i) {
-  # order the proportions of each row
-  o <- order(i, decreasing = TRUE)
-  # determine a cut point for cumulative proportion >= threshold value
-  thresh.n <- which(cumsum(i[o]) >= 0.75)[1]
-  # if there is only a single class that dominates, then offset index as we subtract 1 next
-  if(thresh.n == 1)
-    thresh.n <- 2
-  # get the top classes
-  top.classes <- i[o][1:(thresh.n-1)]
-  # format for adding to a table
-  paste(names(top.classes), collapse = '/')
-}
-)
-# prepare for printing HTML table
-x.sig <- as.data.frame(x.sig)
-names(x.sig) <- 'landform signature'
-
-# get a geomorphon signature for each polygon
-geomorphon.spatial.summary <- ddply(d.geomorphons, c('pID', '.id'), .fun=function(i) {
-  # drop unused map unit .id levels: we are only interested in the _current_ MU
-  i$.id <- factor(i$.id)
-  # tabulate and convert to proportions
-  # retain all geomorphon code levels
-  x <- xtabs(~ .id + value, data=i, drop.unused.levels = FALSE)
-  x <- sweep(x, MARGIN = 1, STATS = rowSums(x), FUN = '/')
-  return(x)
-})
-
-## consider supervised classification for QC at this stage:
-# r <- randomForest(factor(.id) ~ ., data=geomorphon.spatial.summary[, -1])
-# geomorphon.spatial.summary$pred.id <- predict(r, geomorphon.spatial.summary)
-
-## most likely landform
-most.likely.landform.idx <- apply(geomorphon.spatial.summary[, -c(1:2)], 1, which.max)
-geomorphon.spatial.summary$ml_landform <- levels(d.geomorphons$value)[most.likely.landform.idx]
-
-## shannon H by polygon
-geomorphon.spatial.summary$shannon_h <- apply(geomorphon.spatial.summary[, 3:10], 1, function(i) {
-  -sum(i * log(i, base=10), na.rm=TRUE)
-})
-
-## TODO: is this of any use?
-# bwplot(.id ~ shannon_h, data=geomorphon.spatial.summary, xlab='Shannon Entropy', varwidth=TRUE, notch=TRUE)
-
-
-## convert proportions to long format for plotting
-x.long <- melt(x)
-# fix names: second column contains geomorphon labels
-names(x.long)[2] <- 'geomorphon'
-
-# make some colors, and set style
-cols.geomorphons <- c('grey', brewer.pal(9, 'Spectral'))
-tps <- list(superpose.polygon=list(col=cols.geomorphons, lwd=2, lend=2))
-
-# clustering of proportions only works with >1 group
-if(length(unique(x.long$.id)) > 1) {
-  # cluster proportions
-  x.d <- as.hclust(diana(daisy(x)))
-  # re-order MU labels levels based on clustering
-  x.long$.id <- factor(x.long$.id, levels=x.long$.id[x.d$order])
+```{r, echo=FALSE, fig.width=12, fig.height=6, results="asis"}
+makeCategoricalOutput <- function(dat, do.spatial.summary=T) {
+  variable.name = unique(dat$variable)[1] #this just takes first name; fn intended to be called via lapply w/ list of dataframes 1 frame per var
+  pat = variableNameToPattern(variable.name)
   
-  # musym are re-ordered according to clustering
-  trellis.par.set(tps)
-  barchart(.id ~ value, groups=geomorphon, data=x.long, horiz=TRUE, stack=TRUE, xlab='Proportion of Samples', scales=list(cex=1.5), key=simpleKey(space='top', columns=5, text=levels(x.long$geomorphon), rectangles = TRUE, points=FALSE), legend=list(right=list(fun=dendrogramGrob, args=list(x = as.dendrogram(x.d), side="right", size=10))))
-} else {
-  # re-order MU labels levels based on clustering
-  x.long$.id <- factor(x.long$.id)
+  metadat <- lvls <- lbls <- list()
   
+  if(is.null(pat)) {
+    metadat$header=variable.name #if no specific metadata for this variable, use the variable name as used in config file as header
+    metadat$description = "" #TODO: read from XML of raster?
+    metadat$levels = unique(dat$value)
+    metadat$labels = metadat$levels #does nothing special... one value = one label as character
+    lvls=metadat$levels
+    lbls=metadat$labels
+    metadat$colors = brewer.pal(length(metadat$levels), 'Spectral')
+                    #makeNiceColors() #tries to get contrasting colors if the number of classes is sufficiently small (<= 7) doesnt seem to work AB
+    metadat$decimals = 2
+    dat$value=factor(dat$value, levels=metadat$levels, labels=metadat$labels)
+  } else {
+    metadat <- categorical.defs[[pat]] #get the metadata if defined
+    flag = FALSE
+    if(!is.null(metadat$keep.all.classes)) #do not have to specify keep all classes, optional parameter. 
+      if(metadat$keep.all.classes) 
+        flag=TRUE     
+    if(!flag) {
+      lvls=metadat$levels[metadat$levels %in% dat$value] #default behavior is to remove extraneous classes for table readability
+      lbls=metadat$labels[metadat$levels %in% lvls]
+    } else {
+      lvls=metadat$levels
+      lbls=metadat$labels
+    }
+    dat$value=factor(dat$value, levels=lvls, labels=lbls)
+  }
+  
+  cat(paste0("  \n###", metadat$header,"  \n"))
+  if(!is.null(metadat$description))  {
+    cat(paste0("  \n",metadat$description,"  \n"))
+  }
+  if(!is.null(metadat$usage))  {
+    cat("  \n  **Suggested usage:**  \n")
+    cat(paste0("  \n",metadat$usage,"  \n  \n"))
+  }
+  
+  x <- sweepProportions(dat)
+  
+  # remove 0's
+  idx <- which(apply(x, 2, function(i) any(i > 0.001)))
+  # ensure that result is an object that can be converted to a data.frame: use drop=FALSE
+  
+  #now remove the extra classes if we had to drop a class after determining proportions to be too small
+  # this ensures that the correct color is used for each class
+  bad.vars.flag <- (!lbls %in% colnames(x[, -idx]))
+  lvls <- lvls[bad.vars.flag]
+  lbls <- lbls[bad.vars.flag]
+  
+  x <- x[, idx, drop=FALSE]
+  x.long <- melt(x)
+  names(x.long)[2] <- "label"
+  x.long[,1] <- factor(x.long[,1],levels=levels(factor(mu.set))) #what on earth why do i have to do this
+  
+  # create a signature of the most frequent classes that sum to 75% or
+  x.sig <- apply(x, 1, function(i) {
+      # order the proportions of each row
+      o <- order(i, decreasing = TRUE)
+      # determine a cut point for cumulative proportion >= threshold value
+      thresh.n <- which(cumsum(i[o]) >= 0.75)[1]
+      # if there is only a single class that dominates, then offset index as we subtract 1 next
+      if(thresh.n == 1)
+        thresh.n <- 2
+      # get the top classes
+      top.classes <- i[o][1:(thresh.n-1)]
+      # format for adding to a table
+      paste(names(top.classes), collapse = '/')
+    })
+  x.sig <- as.data.frame(x.sig)
+  names(x.sig) <- 'mapunit composition "signature" (most frequent classes that sum to 75% or more)'
+  
+  # get a signature for each polygon
+  spatial.summary <- ddply(dat, c( '.id','pID'), .fun=sweepProportions, drop.unused.levels=FALSE)
+  
+  ## consider supervised classification for QC at this stage:
+  # r <- randomForest(factor(.id) ~ ., data=geomorphon.spatial.summary[, -1])
+  # geomorphon.spatial.summary$pred.id <- predict(r, geomorphon.spatial.summary)
+  
+  ## most likely landform
+  most.likely.class.idx <- apply(spatial.summary[, -c(1:2)], 1, which.max)
+  spatial.summary[[paste0('ml_',variable.name)]] <- levels(dat$value)[most.likely.class.idx]
+  
+  ## shannon H by polygon
+  spatial.summary[[paste0('shannon_h_',variable.name)]] <- apply(spatial.summary[, -c(1,2,length(names(spatial.summary)))], 1, function(i) {
+    -sum(i * log(i, base=10), na.rm=TRUE)
+  })
+  
+  colors=metadat$colors[metadat$levels %in% lvls]
+  tps <- list(superpose.polygon=list(col=colors, lwd=2, lend=2))
   trellis.par.set(tps)
-  barchart(.id ~ value, groups=geomorphon, data=x.long, horiz=TRUE, stack=TRUE, xlab='Proportion of Samples', scales=list(cex=1.5), key=simpleKey(space='top', columns=5, text=levels(x.long$geomorphon), rectangles = TRUE, points=FALSE))
+
+  if(length(unique(x.long$.id)) > 1 & do.spatial.summary) {
+    # cluster proportions
+    x.d <- as.hclust(diana(daisy(x)))
+    # re-order MU labels levels based on clustering
+    x.long$.id <- factor(x.long$.id, levels=unique(x.long$.id)[x.d$order])
+    # musym are re-ordered according to clustering
+    cat('  \n  \n')
+    print(barchart(.id ~ value, groups=x.long$label, data=x.long, horiz=TRUE, stack=TRUE, xlab='Proportion of Samples', scales=list(cex=1.5), key=simpleKey(space='top', columns=3, text=levels(factor(x.long$label)), rectangles = TRUE, points=FALSE),legend=list(right=list(fun=dendrogramGrob, args=list(x = as.dendrogram(x.d), side="right", size=10)))))
+    cat('  \n  \n')
+  } else {
+    # re-order MU labels levels based on order()
+    x.long$.id <- factor(x.long$.id, levels=factor(x.long$.id))
+    
+    trellis.par.set(tps)
+    cat('  \n  \n')
+    print(barchart(.id ~ value, groups=x.long$label, data=x.long, horiz=TRUE, stack=TRUE, xlab='Proportion of Samples', scales=list(cex=1.5), key=simpleKey(space='top', columns=3, text=levels(factor(x.long$label)), rectangles = TRUE, points=FALSE)))
+    cat('  \n  \n')
+  }  
+  print(kable(x, digits = metadat$decimals))
+  cat('  \n  \n')
+  if(do.spatial.summary) {
+    print(kable(x.sig))
+    cat('  \n  \n')
+    mu <- merge(mu, spatial.summary, by='pID', all.x=TRUE)
+  }
+  return(TRUE)
 }
+l <- lapply(split(d.cat, f=d.cat$variable),FUN=makeCategoricalOutput)
 ```
-
-```{r, echo=FALSE, eval=do.geomorphons}
-# print and truncate to 2 decimal places
-kable(x, digits = 2, caption = '')
-```
-
-
-```{r, echo=FALSE, eval=do.geomorphons}
-kable(x.sig, caption = 'Landform "signatures": these are created from the top 75% fraction of (sampled) landform classes, in decreasing order.')
-```
-
-
-### Landcover Summary
-
-These values are from the [2011 NLCD](https://www.mrlc.gov/nlcd2011.php) (30m) database.
-
-```{r, echo=FALSE, fig.width=12, fig.height=8, eval=do.nlcd.classes}
-# These are from the NLCD 2011 metadata
-nlcd.leg <- structure(list(ID = c(0L, 11L, 12L, 21L, 22L, 23L, 24L, 31L, 
-41L, 42L, 43L, 51L, 52L, 71L, 72L, 73L, 74L, 81L, 82L, 90L, 95L
-), name = c("nodata", "Open Water", "Perennial Ice/Snow", "Developed, Open Space", 
-"Developed, Low Intensity", "Developed, Medium Intensity", "Developed, High Intensity", 
-"Barren Land (Rock/Sand/Clay)", "Deciduous Forest", "Evergreen Forest", 
-"Mixed Forest", "Dwarf Scrub", "Shrub/Scrub", "Grassland/Herbaceous", 
-"Sedge/Herbaceous", "Lichens", "Moss", "Pasture/Hay", "Cultivated Crops", 
-"Woody Wetlands", "Emergent Herbaceous Wetlands"), col = c("#000000", 
-"#476BA0", "#D1DDF9", "#DDC9C9", "#D89382", "#ED0000", "#AA0000", 
-"#B2ADA3", "#68AA63", "#1C6330", "#B5C98E", "#A58C30", "#CCBA7C", 
-"#E2E2C1", "#C9C977", "#99C147", "#77AD93", "#DBD83D", "#AA7028", 
-"#BAD8EA", "#70A3BA")), .Names = c("ID", "name", "col"), row.names = c(NA, 
--21L), class = "data.frame")
-
-# set factor levels
-d.nlcd.classes$value <- factor(d.nlcd.classes$value, 
-                                    levels = nlcd.leg$ID, 
-                                    labels = nlcd.leg$name)
-
-# tabulate and convert to proportions
-x <- xtabs(~ .id + value, data=d.nlcd.classes)
-# rounding to remove "tiny" fractions -> simpler legend
-x <- round(sweep(x, MARGIN = 1, STATS = rowSums(x), FUN = '/'), 3)
-
-# remove 0's
-idx <- which(apply(x, 2, function(i) any(i > 0.001)))
-# ensure that result is an object that can be converted to a data.frame: use drop=FALSE
-x <- x[, idx, drop=FALSE]
-
-# convert to long format for plotting
-x.long <- melt(x)
-# fix names: second column contains NLCD class labels
-names(x.long)[2] <- 'nlcd.class'
-
-
-# These are from the NLCD 2011 metadata
-# get colors for only those classes in this data
-cols.nlcd.classes <- nlcd.leg$col[match(levels(x.long$nlcd.class), nlcd.leg$name)]
-tps <- list(superpose.polygon=list(col=cols.nlcd.classes, lwd=2, lend=2))
-
-# no re-ordering of musym
-trellis.par.set(tps)
-barchart(as.character(.id) ~ value, groups=nlcd.class, data=x.long, horiz=TRUE, stack=TRUE, xlab='Proportion of Samples', scales=list(cex=1.5), key=simpleKey(space='top', columns=3, text=levels(x.long$nlcd.class), rectangles = TRUE, points=FALSE))
-```
-
-```{r, echo=FALSE, eval=do.nlcd.classes}
-# print and truncate to 2 decimal places
-kable(x, digits = 2, caption = '')
-```
-
 
 ### Multivariate Summary
 
@@ -1008,13 +709,8 @@ write.csv(poly.stats.wide, file=poly.stats.fname, row.names=FALSE)
 mu <- merge(mu, poly.stats.wide, by='pID', all.x=TRUE)
 names(mu)[-1] <- abbreviateNames(mu)
 
-## join geomorphon class stats to attribute table
-if(do.geomorphons)
-  mu <- merge(mu, geomorphon.spatial.summary, by='pID', all.x=TRUE)
-
 # remove internally-used MU ID
 mu$.id <- NULL
-
 
 # save to file
 shp.fname <- paste0('polygons-with-stats-', paste(mu.set, collapse='_'))

--- a/inst/reports/region2/mu-comparison/report.Rmd
+++ b/inst/reports/region2/mu-comparison/report.Rmd
@@ -1,6 +1,11 @@
 ---
 title: null
-output: html_document
+output:
+  html_document:
+    mathjax: null
+    jquery: null
+    smart: no
+    keep_md: no
 ---
 
 ```{r setup, echo=FALSE, results='hide', warning=FALSE, message=FALSE}

--- a/inst/reports/region2/mu-comparison/report.Rmd
+++ b/inst/reports/region2/mu-comparison/report.Rmd
@@ -1,15 +1,9 @@
 ---
 title: null
-output:
-  html_document:
-    mathjax: null
-    jquery: null
-    smart: no
-    keep_md: no
+output: html_document
 ---
 
 ```{r setup, echo=FALSE, results='hide', warning=FALSE, message=FALSE}
-# setup
 library(knitr, quietly=TRUE)
 
 # package options
@@ -21,179 +15,11 @@ opts_chunk$set(message=FALSE, warning=FALSE, background='#F7F7F7', fig.align='ce
 # R session options
 options(width=100, stringsAsFactors=FALSE)
 
+## load dependencies
 
-## custom functions
+#TODO: verify that these have been installed and correct version. Just as a sanity check, should check version being compatible with report manifest
+# reportSetup should do this on creation of the report instance (see soilReports issue #45 on GH)
 
-# remove NA from $value
-# compute density for $value, using 1.5x "default" bandwidth
-# re-scale to {0,1}
-# return x,y values
-scaled.density <- function(d) {
-  res <- stats::density(na.omit(d$value), kernel='gaussian', adjust=1.5)
-  return(data.frame(x=res$x, y=scales::rescale(res$y)))
-}
-
-
-abbreviateNames <- function(spdf) {
- sapply(names(spdf)[-1], function(i) {
-  # keep only alpha and underscore characters in field names
-  i <- gsub('[^[:alpha:]_]', '', i)
-  # abbreviate after filtering other bad chars
-  abbr <- abbreviate(i, minlength = 10)
-  return(abbr)
-  })
-}
-
-# return DF with proportions outside range for each polygon (by pID)
-flagPolygons <- function(i) {
-  
-   # convert to values -> quantiles
-  e.i <- ecdf(i$value)
-  q.i <- e.i(i$value)
-  # locate those samples outside of our 5th-95th range
-  out.idx <- which(q.i < 0.05 | q.i > 0.95)
-  
-  ## TODO: may need to protect against no matching rows?
-  tab <- sort(prop.table(table(i$pID[out.idx])), decreasing = TRUE)
-  df <- data.frame(pID=names(tab), prop.outside.range=round(as.vector(tab), 2))
-  
-  # keep only those with > 15% of samples outside of range
-  #df <- df[which(df$prop.outside.range > p.crit), ]  
-  
-  #all proportions outside now reported in QC shapefile; no need to have a threshold
-  return(df)
-}
-
-
-# http://stackoverflow.com/questions/16225530/contours-of-percentiles-on-level-plot
-kdeContours <- function(i, prob, cols, m, ...) {
-  
-  if(nrow(i) < 2) {
-    return(NULL)
-  }
-  
-  this.id <- unique(i$.id)
-  this.col <- cols[match(this.id, m)]
-  dens <- kde2d(i$x, i$y, n=200); ## estimate the z counts
-
-  dx <- diff(dens$x[1:2])
-  dy <- diff(dens$y[1:2])
-  sz <- sort(dens$z)
-  c1 <- cumsum(sz) * dx * dy
-  levels <- sapply(prob, function(x) {
-    approx(c1, sz, xout = 1 - x)$y
-  })
-  
-  # add contours if possibly
-  if(!is.na(levels))
-    contour(dens, levels=levels, drawlabels=FALSE, add=TRUE, col=this.col, ...)
-  
-  # # add bivariate medians
-  # points(median(i$x), median(i$y), pch=3, lwd=2, col=this.col)
-}
-
-
-# masking function applied to a "wide" data.frame of sampled raster data
-# function is applied column-wise
-# note: using \leq and \geq for cases with very narrow distributions
-mask.fun <- function(i) {
-  res <- i >= quantile(i, prob=0.05, na.rm=TRUE) & i <= quantile(i, prob=0.95, na.rm=TRUE)
-  return(res)
-}
-
-
-# cut down to reasonable size: using cLHS
-f.subset <- function(i, n, non.id.vars) {
-	# if there are more than n records, then sub-sample
-	if(nrow(i) > n) {
-	  # columns with IDs have been pre-filtered
-		idx <- clhs(i[, non.id.vars], size=n, progress=FALSE, simple=TRUE, iter=1000)
-		i.sub <- i[idx, ]
-	}
-	#	otherwise use what we have
-	else
-		i.sub <- i
-	
-	return(i.sub)
-}
-
-
-# set multi-row figure based on number of groups and fixed number of columns
-dynamicPar <- function(n, max.cols=3) {
-  # simplest case, fewer than max number of allowed columns
-  if(n <= max.cols) {
-    n.rows <- 1
-    n.cols <- n
-  } else {
-    
-    # simplest case, a square
-    if(n %% max.cols == 0) {
-      n.rows <- n / max.cols
-      n.cols <- max.cols
-    } else {
-      # ragged
-      n.rows <- round(n / max.cols) + 1
-      n.cols <- max.cols
-    }
-  }
-  
-  par(mar=c(0,0,0,0), mfrow=c(n.rows, n.cols))
-  # invisibly return geometry
-  invisible(c(n.rows, n.cols))
-}
-
-# stat summary function
-f.summary <- function(i, p) {
-  
-  # remove NA
-  v <- na.omit(i$value)
-  
-  # compute quantiles
-  q <- quantile(v, probs=p)
-  res <- data.frame(t(q))
-  
-  ## TODO: implement better MADM processing and explanation  
-  if(nrow(res) > 0) {
-#     # MADM: MAD / median
-#     # take the natural log of absolute values of MADM
-#     res$log_abs_madm <- log(abs(mad(v) / median(v)))
-#     # 0's become -Inf: convert to 0
-#     res$log_abs_madm[which(is.infinite(res$log_abs_madm))] <- 0
-    
-    # assign reasonable names (quantiles)
-    names(res) <- c(paste0('Q', p * 100))
-    
-    return(res)
-  }
-  else
-    return(NULL)
-}
-
-# custom stats for box-whisker plot: 5th-25th-50th-75th-95th percentiles
-# NOTE: we are re-purposing the coef argument!
-# x: vector of values to summarize
-# coef: Moran's I associated with the current raster
-custom.bwplot <- function(x, coef=NA, do.out=FALSE) {
-  # custom quantiles for bwplot
-  stats <- quantile(x, p=c(0.05, 0.25, 0.5, 0.75, 0.95), na.rm = TRUE)
-  # number of samples
-  n <- length(na.omit(x))
-  
-  # compute effective sample size
-  rho <- coef
-  n_eff <- ESS_by_Moran_I(n, rho)
-  
-  # confidence "notch" is based on ESS
-  iqr <- stats[4] - stats[2]
-  conf <- stats[3] + c(-1.58, 1.58) * iqr/sqrt(n_eff)
-  
-  out.low <- x[which(x < stats[1])]
-  out.high <- x[which(x > stats[5])]
-  
-  return(list(stats=stats, n=n, conf=conf, out=c(out.low, out.high)))
-}
-
-# load required packages
 library(MASS, quietly=TRUE)
 library(rgdal, quietly=TRUE)
 library(rgeos, quietly=TRUE)
@@ -207,58 +33,44 @@ library(clhs, quietly=TRUE)
 library(randomForest, quietly=TRUE)
 library(spdep, quietly=TRUE)
 
+## load report-specific functions
+source('custom.R') 
 
-## load local configuration
+## load local configuration 
+#TODO: allow entry of simple fields interactively if they are not specified?
+#TODO: allow for batching from a basic report.Rmd
 source('config.R')
-```
 
-
-```{r, echo=FALSE, results='hide'}
-# load map unit polygons from OGR data source
+## load map unit polygons from OGR data source
 mu <- try(readOGR(dsn=mu.dsn, layer=mu.layer, stringsAsFactors = FALSE))
 if(class(mu) == 'try-error')
   stop(paste0('Cannot find map unit polygon file/feature: "', mu.dsn, ' / ', mu.layer, '"'), call. = FALSE)
 
-# just in case, coerce mu.col to character
-mu[[mu.col]] <- as.character(mu[[mu.col]])
+mu[[mu.col]] <- as.character(mu[[mu.col]]) # just in case, coerce mu.col to character
 
 # if no filter, then keep all map units
-if(exists('mu.set')) {
+if(exists('mu.set')) { #TODO: this type of if(exists(obj)) needs to wrap all references to report parameters 
   # coerce mu.set to character just in integers were specified
   mu.set <- as.character(mu.set)
-  # filter
-  mu <- mu[which(mu[[mu.col]] %in% mu.set), ]
-  # just in case an MU is specified that doesn't exist, 
-  # keep only those records that made it through the filering step
-  mu.set <- unique(mu[[mu.col]])
-} else {
-  # mu.set not defined in config.R, define using the data on hand
-  mu.set <- unique(mu[[mu.col]])
+  mu <- mu[which(mu[[mu.col]] %in% mu.set), ] # if mu.set defined in config.R, only keep the items from set
 }
-
-# nice colors
-# 7 or fewer classes, use high-constrast colors
-if(length(mu.set) <= 7) {
-  cols <- brewer.pal(9, 'Set1') 
-  # remove light colors
-  cols <- cols[c(1:5,7,9)]
-} else {
-  # otherwise, use 12 paired colors
-  cols <- brewer.pal(12, 'Paired')
-}
+#mu.set <- unique(mu[[mu.col]])# keep only those records that made it through the filering step
 
 # add a unique polygon ID
 mu$pID <- seq(from=1, to=length(mu))
 
-# check for cached data
 if(cache.samples & file.exists('cached-samples.Rda')) {
   message('Using cached raster samples...')
   .sampling.time <- 'using cached samples'
   load('cached-samples.Rda')
 } else {
+  #This script generates an Rda file (R object) containing samples from a set of rasters overlapping a polygon feature class.
+  #Samples are obtained from features of interest using constant density sampling. These data can then be used for summary of the variable space associated with mapunits, geologies, MLRAs, study areas, etc. Several reports have been designed to make use of these datasets. 
   
-  # remove previous samples
-  unlink('cached-samples.Rda')
+  #TODO: check for existence of parameter objects before using them... fail elegantly by asking for user input via knitr?
+  # Sourcing this script succesfully relies on a baseline definition of report parameters in the global environment. 
+  # Needed params and names are based on config.R from v2.5 of mu summary report, though they may be defined in any way that is convenient
+  # (i.e. batch/programattically, interactively, and via static config file)
   
   # suppressing warnings: these have to do with conversion of CRS of points
   # iterate over map units and sample rasters
@@ -266,60 +78,41 @@ if(cache.samples & file.exists('cached-samples.Rda')) {
   .timer.start <- Sys.time()
   sampling.res <- suppressWarnings(sampleRasterStackByMU(mu, mu.set, mu.col, raster.list, pts.per.acre, estimateEffectiveSampleSize = correct.sample.size))
   .timer.stop <- Sys.time()
+  
   .sampling.time <- format(difftime(.timer.stop, .timer.start, units='mins'), digits=2)
-
-  # cache for later
+  print(paste0("Completed sampling of raster stack for poly symbols (",paste(mu.set,collapse=","),") in ",.sampling.time,"."))
+  
+  sampling.res$raster.samples$.id <- factor(sampling.res$raster.samples$.id, levels=mu.set)
+  #TODO: toggle for appending date/time to file name for Rda containing samnples; or take file name as param?
+  save(sampling.res, file=paste0("samples_",paste(mu.set,collapse="_"),"-",strftime(Sys.time(),format="%Y%m%d_%H%M%S"),".Rda"))
+  print("DONE!")
+  
   if(cache.samples)
-    save(sampling.res, file='cached-samples.Rda')
+    save(mu, sampling.res,file = 'cached-samples.Rda')
 }
 
-## convert MU id into factor, using originally specified levels
-sampling.res$raster.samples$.id <- factor(sampling.res$raster.samples$.id, levels=mu.set)
-
-## split raster data into types: continuous, categorical, circular
-d.cat <- subset(sampling.res$raster.samples, variable.type == 'categorical')
-
-## TODO: could there ever be more than one type of circular variable?
+## subset raster samples by data type: continuous, categorical, circular
+d.continuous <- subset(sampling.res$raster.samples, variable.type == 'continuous')
+d.continuous$variable <- factor(d.continuous$variable, levels=names(raster.list$continuous))
 d.circ <- subset(sampling.res$raster.samples, variable.type == 'circular')
 
-## extract continuous raster values
-d.continuous <- subset(sampling.res$raster.samples, variable.type == 'continuous')
-
-# convert "variable" into a factor with the same order as listed in config.R
-d.continuous$variable <- factor(d.continuous$variable, levels=names(raster.list$continuous))
-
-## http://adv-r.had.co.nz/memory.html#memory
-# free-up some memory
-sampling.res$raster.samples <- NULL
-
-## TODO: eventually there should be a function / template for any categorical data
-
 # subset and enable aspect summary
-if(nrow(d.circ) > 0) {
+if(nrow(d.circ) > 0) { ## TODO: could there ever be more than one type of circular variable? 
+#AB: direction of gradient could be determined for basically any raster... but obv. we don't use anything other than direction of slope gradient
   do.aspect <- TRUE
 } else do.aspect <- FALSE
 
-# subset and enable curvature classes
-curvature.classes <- unique(d.cat$variable)[grep('curvature', unique(d.cat$variable), ignore.case = TRUE)]
-if(length(curvature.classes) > 0) {
-  do.curvature.classes <- TRUE
-  d.curvature.classes <- subset(d.cat, subset=variable == curvature.classes)
-} else do.curvature.classes <- FALSE
+### SUBSET CATEGORICAL VARIABLEs
+#d.cat is derived from the sample object resulting from running cLHS_sample_by_polygon.R
+d.cat <- subset(sampling.res$raster.samples, variable.type == 'categorical')
+d.cat$.id <- factor(d.cat$.id,levels=mu.set)
+d.cat.sub <- list()
+categorical.defs <- list()#this defines the aliases and label:value:color sets for displaying categorical variables
+source("categorical_definitions.R") #this will load the structures that define value:label:color for categorical plot. 
+                                    #updates the "section_toggle" variable defined at top of report which will knit the appropriate plots for the specified categoricals from config.R
 
-# subset and enable geomorphons
-geomorphons.vars <- unique(d.cat$variable)[grep('geomorphon', unique(d.cat$variable), ignore.case = TRUE)]
-if(length(geomorphons.vars) > 0) {
-  do.geomorphons <- TRUE
-  d.geomorphons <- subset(d.cat, subset=variable == geomorphons.vars)
-} else do.geomorphons <- FALSE
 
-# subset and enable 2011 NLCD
-nlcd.classes <- unique(d.cat$variable)[grep('nlcd',unique(d.cat$variable), ignore.case = TRUE)]
-if(length(nlcd.classes) > 0) {
-  do.nlcd.classes <- TRUE
-  d.nlcd.classes <- subset(d.cat, subset=variable == nlcd.classes)
-} else do.nlcd.classes <- FALSE
-
+### FORMATTING
 ## figure out reasonable figure heights for bwplots and density plots
 # baseline height for figure margins, axes, and legend
 min.height <- 2 
@@ -327,9 +120,14 @@ min.height <- 2
 panel.height <- 2 * length(levels(d.continuous$variable))
 # extra height for each ID
 id.height <- 0.25 * length(levels(d.continuous$.id))
-
 dynamic.fig.height <- min.height + panel.height + id.height
 
+# nice colors
+cols <- brewer.pal(length(mu.set), 'Spectral')#makeNiceColors()
+
+#TODO: Null out raster samples to save memory TOGGLE
+## http://adv-r.had.co.nz/memory.html#memory
+#sampling.res$raster.samples <- NULL
 ```
 
 <br>
@@ -341,8 +139,6 @@ report version `r .report.version`
 
 <br>
 This report is designed to provide statistical summaries of the environmental properties for one or more map units. Summaries are based on raster data extracted from [fixed-density sampling of map unit polygons](http://ncss-tech.github.io/AQP/sharpshootR/sample-vs-population.html). [Percentiles](https://ncss-tech.github.io/soil-range-in-characteristics/why-percentiles.html) are used as robust metrics of distribution central tendency and spread. Please see the document titled *R-Based Map Unit Summary Report Introduction and Description* for background and setup.
-
-
 
 ### Map Unit Polygon Data Source
 ```{r, echo=FALSE}
@@ -360,8 +156,6 @@ Target sampling density: <b>`r pts.per.acre` points/ac.</b> defined in `config.R
 ```{r, echo=FALSE}
 kable(sampling.res$area.stats, caption='Map Unit Acreage by Polygon', align = 'r', col.names=c(mu.col, names(sampling.res$area.stats)[-1]))
 ```
-
-
 
 
 ### Modified Box and Whisker Plots
@@ -493,225 +287,132 @@ res <- ldply(d.circ.list, function(i) {
 kable(res, align = 'r', col.names=c(mu.col, names(res)[-1]))
 ```
 
-
-### Slope Shape (Curvature) Summary
-The classes were generated using a 5x5 moving window, from a regional 30m or 10m, integer DEM. The precision may be limited, use with caution. See instructions for using your own (higher resolution) curvature classification raster.
-
-**Suggested usage:**
-
- * Use the graphical summary to identify patterns, then consult the tabular representation for specifics.
- * The conventions used here are "C" = concave, "L" = linear, and "V" = convex; "down slope" / "across slope".
- * Window size has a significant impact on reported curvature classes; larger windows = more generalization.
- * Curvature class and colors are aligned with an idealized *shedding* &rarr; *accumulating* hydrologic gradient.
-
-```{r, echo=FALSE, fig.width=12, fig.height=6, eval=do.curvature.classes}
-# set names: from Field Guide for description of soils
-## source data: opposite convention
-# 1's place: profile curvature
-# 10's place: plan curvature
-#
-## adapted from above
-## data are reported down/across slope
-# L/L | L/V | L/C         22 | 32 | 12  
-# V/L | V/V | V/C   ----> 23 | 33 | 13
-# C/L | C/V | C/C         21 | 31 | 11
-#
-# order according to approximate "shedding" -> "accumulating" gradient:
-# 'V/V', 'L/V', 'V/L', 'C/V', 'LL', 'C/L', 'V/C', 'L/C', 'C/C'
-#
-d.curvature.classes$value <- factor(d.curvature.classes$value, 
-                                    levels=c(33, 32, 23, 31, 22, 21, 13, 12, 11), 
-                                    labels = c('V/V', 'L/V', 'V/L', 'C/V', 'LL', 'C/L', 'V/C', 'L/C', 'C/C'))
-
-# tabulate and convert to proportions
-x <- xtabs(~ .id + value, data=d.curvature.classes)
-x <- sweep(x, MARGIN = 1, STATS = rowSums(x), FUN = '/')
-
-# convert to long format for plotting
-x.long <- melt(x)
-# fix names: second column contains curvature class labels
-names(x.long)[2] <- 'curvature.class'
-
-# make some colors, and set style
-cols.curvature.classes <- brewer.pal(9, 'Spectral')
-tps <- list(superpose.polygon=list(col=cols.curvature.classes, lwd=2, lend=2))
-
-# no re-ordering of musym
-trellis.par.set(tps)
-barchart(as.character(.id) ~ value, groups=curvature.class, data=x.long, horiz=TRUE, stack=TRUE, xlab='Proportion of Samples', scales=list(cex=1.5), key=simpleKey(space='top', columns=3, text=levels(x.long$curvature.class), rectangles = TRUE, points=FALSE))
-```
-
-```{r, echo=FALSE, eval=do.curvature.classes}
-# print and truncate to 2 decimal places
-kable(x, digits = 2, caption = '')
-```
-
-
-
-### Geomorphon Landform Classification
-Proportion of samples within each map unit that correspond to 1 of 10 possible landform positions, as generated via [geomorphon](https://grass.osgeo.org/grass70/manuals/addons/r.geomorphon.html) algorithm. Landform classification by [this method](http://dx.doi.org/10.1016/j.geomorph.2012.11.005) is scale-invariant and is therefore not affected by computational window size selection.
-
-
-**Suggested usage:**
-
-  * Use the graphical summary to identify patterns, then consult the tabular representation for specifics.
-  * "Flat" is based on a 3% slope threshold.
-  * Map units are organized (in the figure) according to the similarity, computed from proportions of each landform position.
-  * The [dendrogram](http://ncss-tech.github.io/stats_for_soil_survey/chapter_5.html) on the right side of the figure describes relative similarity. "Lower branch height" (e.g. closer to the right-hand side of the figure) denotes more similar landform positions.
-  * Landform class labels and colors are aligned with an idealized *shedding* &rarr; *accumulating* hydrologic gradient.
-
-```{r, echo=FALSE, eval=do.geomorphons, fig.width=12, fig.height=6}
-## geomorphons:
-# set names
-# https://grass.osgeo.org/grass70/manuals/addons/r.geomorphon.html
-d.geomorphons$value <- factor(d.geomorphons$value, levels=1:10, labels = c('flat', 'summit', 'ridge', 'shoulder', 'spur', 'slope', 'hollow', 'footslope', 'valley', 'depression'))
-
-# tabulate and convert to proportions
-x <- xtabs(~ .id + value, data=d.geomorphons)
-x <- sweep(x, MARGIN = 1, STATS = rowSums(x), FUN = '/')
-
-# create a signature of the most frequent classes that sum to 75% or
-x.sig <- apply(x, 1, function(i) {
-  # order the proportions of each row
-  o <- order(i, decreasing = TRUE)
-  # determine a cut point for cumulative proportion >= threshold value
-  thresh.n <- which(cumsum(i[o]) >= 0.75)[1]
-  # if there is only a single class that dominates, then offset index as we subtract 1 next
-  if(thresh.n == 1)
-    thresh.n <- 2
-  # get the top classes
-  top.classes <- i[o][1:(thresh.n-1)]
-  # format for adding to a table
-  paste(names(top.classes), collapse = '/')
-}
-)
-# prepare for printing HTML table
-x.sig <- as.data.frame(x.sig)
-names(x.sig) <- 'landform signature'
-
-# get a geomorphon signature for each polygon
-geomorphon.spatial.summary <- ddply(d.geomorphons, c('pID', '.id'), .fun=function(i) {
-  # drop unused map unit .id levels: we are only interested in the _current_ MU
-  i$.id <- factor(i$.id)
-  # tabulate and convert to proportions
-  # retain all geomorphon code levels
-  x <- xtabs(~ .id + value, data=i, drop.unused.levels = FALSE)
-  x <- sweep(x, MARGIN = 1, STATS = rowSums(x), FUN = '/')
-  return(x)
-})
-
-## consider supervised classification for QC at this stage:
-# r <- randomForest(factor(.id) ~ ., data=geomorphon.spatial.summary[, -1])
-# geomorphon.spatial.summary$pred.id <- predict(r, geomorphon.spatial.summary)
-
-## most likely landform
-most.likely.landform.idx <- apply(geomorphon.spatial.summary[, -c(1:2)], 1, which.max)
-geomorphon.spatial.summary$ml_landform <- levels(d.geomorphons$value)[most.likely.landform.idx]
-
-## shannon H by polygon
-geomorphon.spatial.summary$shannon_h <- apply(geomorphon.spatial.summary[, 3:10], 1, function(i) {
-  -sum(i * log(i, base=10), na.rm=TRUE)
-})
-
-## TODO: is this of any use?
-# bwplot(.id ~ shannon_h, data=geomorphon.spatial.summary, xlab='Shannon Entropy', varwidth=TRUE, notch=TRUE)
-
-
-## convert proportions to long format for plotting
-x.long <- melt(x)
-# fix names: second column contains geomorphon labels
-names(x.long)[2] <- 'geomorphon'
-
-# make some colors, and set style
-cols.geomorphons <- c('grey', brewer.pal(9, 'Spectral'))
-tps <- list(superpose.polygon=list(col=cols.geomorphons, lwd=2, lend=2))
-
-# clustering of proportions only works with >1 group
-if(length(unique(x.long$.id)) > 1) {
-  # cluster proportions
-  x.d <- as.hclust(diana(daisy(x)))
-  # re-order MU labels levels based on clustering
-  x.long$.id <- factor(x.long$.id, levels=x.long$.id[x.d$order])
+```{r, echo=FALSE, fig.width=12, fig.height=6, results="asis"}
+makeCategoricalOutput <- function(dat, do.spatial.summary=T) {
+  variable.name = unique(dat$variable)[1] #this just takes first name; fn intended to be called via lapply w/ list of dataframes 1 frame per var
+  pat = variableNameToPattern(variable.name)
   
-  # musym are re-ordered according to clustering
-  trellis.par.set(tps)
-  barchart(.id ~ value, groups=geomorphon, data=x.long, horiz=TRUE, stack=TRUE, xlab='Proportion of Samples', scales=list(cex=1.5), key=simpleKey(space='top', columns=5, text=levels(x.long$geomorphon), rectangles = TRUE, points=FALSE), legend=list(right=list(fun=dendrogramGrob, args=list(x = as.dendrogram(x.d), side="right", size=10))))
-} else {
-  # re-order MU labels levels based on clustering
-  x.long$.id <- factor(x.long$.id)
+  metadat <- lvls <- lbls <- list()
   
+  if(is.null(pat)) {
+    metadat$header=variable.name #if no specific metadata for this variable, use the variable name as used in config file as header
+    metadat$description = "" #TODO: read from XML of raster?
+    metadat$levels = unique(dat$value)
+    metadat$labels = metadat$levels #does nothing special... one value = one label as character
+    lvls=metadat$levels
+    lbls=metadat$labels
+    metadat$colors = brewer.pal(length(metadat$levels), 'Spectral')
+                    #makeNiceColors() #tries to get contrasting colors if the number of classes is sufficiently small (<= 7) doesnt seem to work AB
+    metadat$decimals = 2
+    dat$value=factor(dat$value, levels=metadat$levels, labels=metadat$labels)
+  } else {
+    metadat <- categorical.defs[[pat]] #get the metadata if defined
+    flag = FALSE
+    if(!is.null(metadat$keep.all.classes)) #do not have to specify keep all classes, optional parameter. 
+      if(metadat$keep.all.classes) 
+        flag=TRUE     
+    if(!flag) {
+      lvls=metadat$levels[metadat$levels %in% dat$value] #default behavior is to remove extraneous classes for table readability
+      lbls=metadat$labels[metadat$levels %in% lvls]
+    } else {
+      lvls=metadat$levels
+      lbls=metadat$labels
+    }
+    dat$value=factor(dat$value, levels=lvls, labels=lbls)
+  }
+  
+  cat(paste0("  \n###", metadat$header,"  \n"))
+  if(!is.null(metadat$description))  {
+    cat(paste0("  \n",metadat$description,"  \n"))
+  }
+  if(!is.null(metadat$usage))  {
+    cat("  \n  **Suggested usage:**  \n")
+    cat(paste0("  \n",metadat$usage,"  \n  \n"))
+  }
+  
+  x <- sweepProportions(dat)
+  
+  # remove 0's
+  idx <- which(apply(x, 2, function(i) any(i > 0.001)))
+  # ensure that result is an object that can be converted to a data.frame: use drop=FALSE
+  
+  #now remove the extra classes if we had to drop a class after determining proportions to be too small
+  # this ensures that the correct color is used for each class
+  bad.vars.flag <- (!lbls %in% colnames(x[, -idx]))
+  lvls <- lvls[bad.vars.flag]
+  lbls <- lbls[bad.vars.flag]
+  
+  x <- x[, idx, drop=FALSE]
+  x.long <- melt(x)
+  names(x.long)[2] <- "label"
+  x.long[,1] <- factor(x.long[,1],levels=levels(factor(mu.set))) #what on earth why do i have to do this
+  
+  # create a signature of the most frequent classes that sum to 75% or
+  x.sig <- apply(x, 1, function(i) {
+      # order the proportions of each row
+      o <- order(i, decreasing = TRUE)
+      # determine a cut point for cumulative proportion >= threshold value
+      thresh.n <- which(cumsum(i[o]) >= 0.75)[1]
+      # if there is only a single class that dominates, then offset index as we subtract 1 next
+      if(thresh.n == 1)
+        thresh.n <- 2
+      # get the top classes
+      top.classes <- i[o][1:(thresh.n-1)]
+      # format for adding to a table
+      paste(names(top.classes), collapse = '/')
+    })
+  x.sig <- as.data.frame(x.sig)
+  names(x.sig) <- 'mapunit composition "signature" (most frequent classes that sum to 75% or more)'
+  
+  # get a signature for each polygon
+  spatial.summary <- ddply(dat, c( '.id','pID'), .fun=sweepProportions, drop.unused.levels=FALSE)
+  
+  ## consider supervised classification for QC at this stage:
+  # r <- randomForest(factor(.id) ~ ., data=geomorphon.spatial.summary[, -1])
+  # geomorphon.spatial.summary$pred.id <- predict(r, geomorphon.spatial.summary)
+  
+  ## most likely landform
+  most.likely.class.idx <- apply(spatial.summary[, -c(1:2)], 1, which.max)
+  spatial.summary[[paste0('ml_',variable.name)]] <- levels(dat$value)[most.likely.class.idx]
+  
+  ## shannon H by polygon
+  spatial.summary[[paste0('shannon_h_',variable.name)]] <- apply(spatial.summary[, -c(1,2,length(names(spatial.summary)))], 1, function(i) {
+    -sum(i * log(i, base=10), na.rm=TRUE)
+  })
+  
+  colors=metadat$colors[metadat$levels %in% lvls]
+  tps <- list(superpose.polygon=list(col=colors, lwd=2, lend=2))
   trellis.par.set(tps)
-  barchart(.id ~ value, groups=geomorphon, data=x.long, horiz=TRUE, stack=TRUE, xlab='Proportion of Samples', scales=list(cex=1.5), key=simpleKey(space='top', columns=5, text=levels(x.long$geomorphon), rectangles = TRUE, points=FALSE))
+
+  if(length(unique(x.long$.id)) > 1 & do.spatial.summary) {
+    # cluster proportions
+    x.d <- as.hclust(diana(daisy(x)))
+    # re-order MU labels levels based on clustering
+    x.long$.id <- factor(x.long$.id, levels=unique(x.long$.id)[x.d$order])
+    # musym are re-ordered according to clustering
+    cat('  \n  \n')
+    print(barchart(.id ~ value, groups=x.long$label, data=x.long, horiz=TRUE, stack=TRUE, xlab='Proportion of Samples', scales=list(cex=1.5), key=simpleKey(space='top', columns=3, text=levels(factor(x.long$label)), rectangles = TRUE, points=FALSE),legend=list(right=list(fun=dendrogramGrob, args=list(x = as.dendrogram(x.d), side="right", size=10)))))
+    cat('  \n  \n')
+  } else {
+    # re-order MU labels levels based on order()
+    x.long$.id <- factor(x.long$.id, levels=factor(x.long$.id))
+    
+    trellis.par.set(tps)
+    cat('  \n  \n')
+    print(barchart(.id ~ value, groups=x.long$label, data=x.long, horiz=TRUE, stack=TRUE, xlab='Proportion of Samples', scales=list(cex=1.5), key=simpleKey(space='top', columns=3, text=levels(factor(x.long$label)), rectangles = TRUE, points=FALSE)))
+    cat('  \n  \n')
+  }  
+  print(kable(x, digits = metadat$decimals))
+  cat('  \n  \n')
+  if(do.spatial.summary) {
+    print(kable(x.sig))
+    cat('  \n  \n')
+    mu <- merge(mu, spatial.summary, by='pID', all.x=TRUE)
+  }
+  return(TRUE)
 }
+l <- lapply(split(d.cat, f=d.cat$variable),FUN=makeCategoricalOutput)
 ```
-
-```{r, echo=FALSE, eval=do.geomorphons}
-# print and truncate to 2 decimal places
-kable(x, digits = 2, caption = '')
-```
-
-
-```{r, echo=FALSE, eval=do.geomorphons}
-kable(x.sig, caption = 'Landform "signatures": these are created from the top 75% fraction of (sampled) landform classes, in decreasing order.')
-```
-
-
-### Landcover Summary
-
-These values are from the [2011 NLCD](https://www.mrlc.gov/nlcd2011.php) (30m) database.
-
-```{r, echo=FALSE, fig.width=12, fig.height=8, eval=do.nlcd.classes}
-# These are from the NLCD 2011 metadata
-nlcd.leg <- structure(list(ID = c(0L, 11L, 12L, 21L, 22L, 23L, 24L, 31L, 
-41L, 42L, 43L, 51L, 52L, 71L, 72L, 73L, 74L, 81L, 82L, 90L, 95L
-), name = c("nodata", "Open Water", "Perennial Ice/Snow", "Developed, Open Space", 
-"Developed, Low Intensity", "Developed, Medium Intensity", "Developed, High Intensity", 
-"Barren Land (Rock/Sand/Clay)", "Deciduous Forest", "Evergreen Forest", 
-"Mixed Forest", "Dwarf Scrub", "Shrub/Scrub", "Grassland/Herbaceous", 
-"Sedge/Herbaceous", "Lichens", "Moss", "Pasture/Hay", "Cultivated Crops", 
-"Woody Wetlands", "Emergent Herbaceous Wetlands"), col = c("#000000", 
-"#476BA0", "#D1DDF9", "#DDC9C9", "#D89382", "#ED0000", "#AA0000", 
-"#B2ADA3", "#68AA63", "#1C6330", "#B5C98E", "#A58C30", "#CCBA7C", 
-"#E2E2C1", "#C9C977", "#99C147", "#77AD93", "#DBD83D", "#AA7028", 
-"#BAD8EA", "#70A3BA")), .Names = c("ID", "name", "col"), row.names = c(NA, 
--21L), class = "data.frame")
-
-# set factor levels
-d.nlcd.classes$value <- factor(d.nlcd.classes$value, 
-                                    levels = nlcd.leg$ID, 
-                                    labels = nlcd.leg$name)
-
-# tabulate and convert to proportions
-x <- xtabs(~ .id + value, data=d.nlcd.classes)
-# rounding to remove "tiny" fractions -> simpler legend
-x <- round(sweep(x, MARGIN = 1, STATS = rowSums(x), FUN = '/'), 3)
-
-# remove 0's
-idx <- which(apply(x, 2, function(i) any(i > 0.001)))
-# ensure that result is an object that can be converted to a data.frame: use drop=FALSE
-x <- x[, idx, drop=FALSE]
-
-# convert to long format for plotting
-x.long <- melt(x)
-# fix names: second column contains NLCD class labels
-names(x.long)[2] <- 'nlcd.class'
-
-
-# These are from the NLCD 2011 metadata
-# get colors for only those classes in this data
-cols.nlcd.classes <- nlcd.leg$col[match(levels(x.long$nlcd.class), nlcd.leg$name)]
-tps <- list(superpose.polygon=list(col=cols.nlcd.classes, lwd=2, lend=2))
-
-# no re-ordering of musym
-trellis.par.set(tps)
-barchart(as.character(.id) ~ value, groups=nlcd.class, data=x.long, horiz=TRUE, stack=TRUE, xlab='Proportion of Samples', scales=list(cex=1.5), key=simpleKey(space='top', columns=3, text=levels(x.long$nlcd.class), rectangles = TRUE, points=FALSE))
-```
-
-```{r, echo=FALSE, eval=do.nlcd.classes}
-# print and truncate to 2 decimal places
-kable(x, digits = 2, caption = '')
-```
-
 
 ### Multivariate Summary
 
@@ -1000,13 +701,8 @@ write.csv(poly.stats.wide, file=poly.stats.fname, row.names=FALSE)
 mu <- merge(mu, poly.stats.wide, by='pID', all.x=TRUE)
 names(mu)[-1] <- abbreviateNames(mu)
 
-## join geomorphon class stats to attribute table
-if(do.geomorphons)
-  mu <- merge(mu, geomorphon.spatial.summary, by='pID', all.x=TRUE)
-
 # remove internally-used MU ID
 mu$.id <- NULL
-
 
 # save to file
 shp.fname <- paste0('polygons-with-stats-', paste(mu.set, collapse='_'))

--- a/inst/reports/region2/mu-comparison/report.Rmd
+++ b/inst/reports/region2/mu-comparison/report.Rmd
@@ -111,7 +111,6 @@ categorical.defs <- list()#this defines the aliases and label:value:color sets f
 source("categorical_definitions.R") #this will load the structures that define value:label:color for categorical plot. 
                                     #updates the "section_toggle" variable defined at top of report which will knit the appropriate plots for the specified categoricals from config.R
 
-
 ### FORMATTING
 ## figure out reasonable figure heights for bwplots and density plots
 # baseline height for figure margins, axes, and legend
@@ -379,7 +378,7 @@ makeCategoricalOutput <- function(dat, do.spatial.summary=T) {
   spatial.summary[[paste0('shannon_h_',variable.name)]] <- apply(spatial.summary[, -c(1,2,length(names(spatial.summary)))], 1, function(i) {
     -sum(i * log(i, base=10), na.rm=TRUE)
   })
-  
+
   colors=metadat$colors[metadat$levels %in% lvls]
   tps <- list(superpose.polygon=list(col=colors, lwd=2, lend=2))
   trellis.par.set(tps)

--- a/inst/reports/region2/mu-comparison/setup.R
+++ b/inst/reports/region2/mu-comparison/setup.R
@@ -10,11 +10,11 @@
 ## version number
 
 .report.name <- 'mu-comparison'
-.report.version <- '2.5'
+.report.version <- '3.0'
 .report.description <- 'compare stack of raster data, sampled from polygons associated with 1-8 map units'
 
-.paths.to.copy <- c('report.Rmd','config.R','NOTES.md','changes.txt')
-.update.paths.to.copy <- c('report.Rmd','NOTES.md','changes.txt')
+.paths.to.copy <- c('report.Rmd','custom.R','config.R','categorical_definitions.R','NOTES.md','changes.txt')
+.update.paths.to.copy <- c('report.Rmd','custom.R','NOTES.md','changes.txt')
 
 .packages.to.get <- c('knitr', 'rmarkdown', 'rgdal', 'raster', 'plyr', 'reshape2', 'Hmisc', 'aqp', 'soilDB', 'sharpshootR', 'latticeExtra', 'clhs', 'devtools', 'rgeos', 'randomForest', 'vegan', 'spdep', 'scales', 'e1071')
 


### PR DESCRIPTION
This pull request will update the region2\mu-comparison report in order to:

- produce reasonable "default" output for arbitrary rasters added to `config.R` as categorical variables
- include a `categorical_definitions.R` file for custom specification of categorical variable symbology/metadata
- moved hardcoded (geomorphon, NLCD, curvature) categoricals into 'definitions' system
- moved some workhorse functions etc. into `custom.R`
- `setup.R` conforms with recent soilReports "report manifest" specs
- automatic output of a .Rda file containing the sample object (can be toggled off, but probably important for data archiving purpose) with informative name (as opposed to cached-samples.Rda) reflecting mapunits sampled and date of report run

Installed the latest version and verified that the report runs with a proper config file. For now I have included the config that works for me -- we will probably need to generalize this when it comes time for wider distribution.