### PR TITLE
Filtering of interactive pedon summary on local phase; updates to use new soilDB column names etc.

### DIFF
--- a/inst/reports/region2/shiny-pedon-summary/changes.txt
+++ b/inst/reports/region2/shiny-pedon-summary/changes.txt
@@ -1,2 +1,3 @@
-2017-07-06: stable version merged into 'master' soilReports branch 
+2017-12-20: incorporated filtering option local phase (also, added to soilDB and fetchNASIS)
+2017-09-06: incorporated filtering option for taxon kind
 2017-04-26: inital commit of cleanish copy; setup for working within soilReports package

--- a/inst/reports/region2/shiny-pedon-summary/config.R
+++ b/inst/reports/region2/shiny-pedon-summary/config.R
@@ -12,13 +12,42 @@ library(xtable)
 library(knitr)
 
 cache_data=F
-use_regex_ghz=F
+use_regex_ghz=T
 
-input <- data.frame(1)
-input$s.mu = '.'
-input$pedon_list=""
+#these are defaults to ensure that the report has inputs necessary to generate plots on startup
+input <- data.frame(1) #create input dataframe
+input$s.mu = '.' #all mapunits
+input$pedon_list="" #no pedon list specified (no initial filter)
 
-gen.hz.rules <- list()
+# "generic" gen.hz.rules for CA630 use
+#   TODO: handle caret, primes etc.
+gen.hz.rules <- list(list(
+  n = c('Oi',
+        'A',
+        'BA',
+        'Bt',
+        'Bw',
+        'Btqm',
+        'Btg',
+        'Bss',
+        'BC',
+        'BCg',
+        'C',
+        'Cr'),
+  p = c('O',
+        '^[2-9]?[AE]B?C?p?d?t?[1-9]?$',
+        '^[2-9]?BA?E?t?[1-9]?$',
+        '^[2-9]?Btb?[1-9]?$',
+        '^[2-9]?Bw[1-9]?$',
+        '^[2-9]?Btqc?m?[1-9]?$',
+        '^[2-9]?Bt?g[1-9]?$',
+        '^[2-9]?B.*ss.*[1-9]?$',
+        '^[2-9]?BCt?c?[1-9]?$',
+        '^[2-9]?BCt?c?g[1-9]?$',
+        '^[2-9]?C[^r]?t?[1-9]?$',
+        '^[2-9]?(C[dr]t?|Rt?)[1-9]?')
+))
+
 
 poly.dsn = "L:/NRCS/MLRAShared/CA630/FG_CA630_OFFICIAL.gdb"
 poly.layer = "ca630_a"

--- a/inst/reports/region2/shiny-pedon-summary/nonreactive.R
+++ b/inst/reports/region2/shiny-pedon-summary/nonreactive.R
@@ -1,15 +1,15 @@
 #makes a dummy "input" data frame fro debugging reactive code from a non-reactive context
 
 input <- data.frame(1)
-input$s.mu = '6054'
-input$component_name="Sierra"
+input$s.mu = '.'
+input$component_name = "."
 input$pedon_pattern = '.'
 input$upid_pattern = '.'
-input$pedon_list=""
-input$modal_pedon="307585:08SMM003"
+input$phase_pattern = "."
+input$taxon_kind = "any"
+input$pedon_list = ""
 input$thematic_field="clay"
-
-input
+#input$modal_pedon = "pedonrecordid:userpedonid" #note: this is dataset specific
 
 s.comp <<- getMapunitComponents(input$s.mu)
 s.pedons <<- getMapunitPedons(input$s.mu)

--- a/inst/reports/region2/shiny-pedon-summary/report.Rmd
+++ b/inst/reports/region2/shiny-pedon-summary/report.Rmd
@@ -7,13 +7,6 @@ output:
     smart: no
     keep_md: no
 ---
-<!-- shiny-pedon-summary (v0.1) -- instance created 2017-08-10 09:34:52-->  
-
-```{r, echo=FALSE, results='hide', warning=FALSE, message=FALSE}
-	.report.name <- 'shiny-pedon-summary'
-	.report.version <- '0.1'
-	.report.description <- 'interactively subset and summarize pedon data from one or more map units'
-```
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = F, message=FALSE, warning = FALSE, fig.align='center', fig.retina=2, dev='png', antialias='cleartype')

--- a/inst/reports/region2/shiny-pedon-summary/report.Rmd
+++ b/inst/reports/region2/shiny-pedon-summary/report.Rmd
@@ -7,7 +7,6 @@ output:
     smart: no
     keep_md: no
 ---
-
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = F, message=FALSE, warning = FALSE, fig.align='center', fig.retina=2, dev='png', antialias='cleartype')
 ```
@@ -106,34 +105,34 @@ Blue line shows the median slab value for the selected set of pedons, with the 2
 
 #### Hillslope position (2D)
 ```{r}
-  df <- categorical.prop.table(peds$hillslope_pos)
+  df <- categorical.prop.table(peds$hillslopeprof)
   kable(df)
   
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
-      print(paste0("Modal pedon value: ",modal$hillslope_pos))
+      print(paste0("Modal pedon value: ",modal$hillslopeprof))
   }
 ```
 
 #### Geomorphic position - Hills (3D)
 ```{r}
-  df <- categorical.prop.table(peds$geompos_hill)
+  df <- categorical.prop.table(peds$geomposhill)
   kable(df)
   
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
-      print(paste0("Modal pedon value: ",modal$geompos_hill))
+      print(paste0("Modal pedon value: ",modal$geomposhill))
   }
 ```
 
 #### Geomorphic position - Mountains (3D)
 ```{r}
-  df <- categorical.prop.table(peds$geompos_mntn)
+  df <- categorical.prop.table(peds$geomposmntn)
   kable(df)
   
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
-      print(paste0("Modal pedon value: ",modal$geompos_mntn))
+      print(paste0("Modal pedon value: ",modal$geomposmntn))
   }
 ```
 
@@ -161,10 +160,8 @@ Blue line shows the median slab value for the selected set of pedons, with the 2
 
 #### Surface Shape (DOWN/ACROSS)
 ```{r}
-  down <- peds$shapedown
-  acro <- peds$shapeacross
-  levels(down) <- c("V","L","C")
-  levels(acro) <- c("V","L","C")
+  down <- factor(as.character(peds$shapedown),labels =  c("V","L","C"), levels=c("convex","linear","concave"))
+  acro <- factor(as.character(peds$shapeacross),labels =  c("V","L","C"), levels=c("convex","linear","concave"))
   shape <- factor(paste(as.character(down),as.character(acro),sep="/"))
   shape[grepl(shape,pattern="NA")] <- NA
   shape <- factor(shape)

--- a/inst/reports/region2/shiny-pedon-summary/report.Rmd
+++ b/inst/reports/region2/shiny-pedon-summary/report.Rmd
@@ -7,6 +7,13 @@ output:
     smart: no
     keep_md: no
 ---
+<!-- shiny-pedon-summary (v0.1) -- instance created 2017-08-10 09:34:52-->  
+
+```{r, echo=FALSE, results='hide', warning=FALSE, message=FALSE}
+	.report.name <- 'shiny-pedon-summary'
+	.report.version <- '0.1'
+	.report.description <- 'interactively subset and summarize pedon data from one or more map units'
+```
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = F, message=FALSE, warning = FALSE, fig.align='center', fig.retina=2, dev='png', antialias='cleartype')
@@ -17,7 +24,7 @@ knitr::opts_chunk$set(echo = F, message=FALSE, warning = FALSE, fig.align='cente
   #outside of reactive context only need to call these once
   sourcemu <- input$s.mu 
   comp <- s.comp
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   peds$genhzraw <- as.character(peds$genhz) #this plot function gets mad if name is a factor...
   s <- summarize.component(peds)
   
@@ -48,11 +55,11 @@ knitr::opts_chunk$set(echo = F, message=FALSE, warning = FALSE, fig.align='cente
 ### Grouped Profile Plot
 ```{r,fig.width=12, fig.height=8}
 #TODO: abstract these with "reactive" and "static" available as a toggle
-groupedProfilePlot(peds,groups = 'taxonname', label='pedon_id', 
+    groupedProfilePlot(peds,groups = 'taxonname', label='pedon_id', 
                          print.id = TRUE, id.style = 'side', cex.id=1.2, 
                          cex.names=1, cex.depth.axis=1.25,y.offset=7, 
                          axis.line.offset=-3.0, group.name.cex=1, 
-                         group.name.offset = -6, color=input$thematic_field,
+                         group.name.offset = c(-6,-10), color=input$thematic_field,
                          width=0.1,shrink=T,shrink.cutoff=3)
 ```
 
@@ -93,7 +100,7 @@ Blue line shows the median slab value for the selected set of pedons, with the 2
                          print.id = TRUE, id.style = 'side', cex.id=1.2, 
                          cex.names=1, cex.depth.axis=1.25,y.offset=7, 
                          axis.line.offset=-3.0, group.name.cex=1, 
-                         group.name.offset = -6, color=input$thematic_field,
+                         group.name.offset = c(-6,-10), color=input$thematic_field,
                          width=0.1,shrink=T,shrink.cutoff=3)
 ```
 

--- a/inst/reports/region2/shiny-pedon-summary/report.Rmd
+++ b/inst/reports/region2/shiny-pedon-summary/report.Rmd
@@ -48,7 +48,7 @@ knitr::opts_chunk$set(echo = F, message=FALSE, warning = FALSE, fig.align='cente
 ### Grouped Profile Plot
 ```{r,fig.width=12, fig.height=8}
 #TODO: abstract these with "reactive" and "static" available as a toggle
-    groupedProfilePlot(peds,groups = 'taxonname', label='pedon_id', 
+groupedProfilePlot(peds,groups = 'taxonname', label='pedon_id', 
                          print.id = TRUE, id.style = 'side', cex.id=1.2, 
                          cex.names=1, cex.depth.axis=1.25,y.offset=7, 
                          axis.line.offset=-3.0, group.name.cex=1, 

--- a/inst/reports/region2/shiny-pedon-summary/setup.R
+++ b/inst/reports/region2/shiny-pedon-summary/setup.R
@@ -12,8 +12,8 @@
 .gh.packages.to.get <- c('ncss-tech/soilDB','ncss-tech/sharpshootR')
 
 .report.name <- 'shiny-pedon-summary'
-.report.version <- '0.1'
-.report.description <- 'interactively subset and summarize pedon data from one or more map units'
+.report.version <- '0.2'
+.report.description <- 'interactively subset and summarize NASIS pedon data from one or more map units'
 
-.paths.to.copy <- c('report.Rmd','shiny.Rmd','utility_functions.R','main.R','config.R','NOTES.md','changes.txt')
+.paths.to.copy <- c('report.Rmd','shiny.Rmd','utility_functions.R','main.R','config.R','changes.txt')
 .update.paths.to.copy <- c('report.Rmd','shiny.Rmd','utility_functions.R','main.R')

--- a/inst/reports/region2/shiny-pedon-summary/shiny.Rmd
+++ b/inst/reports/region2/shiny-pedon-summary/shiny.Rmd
@@ -216,7 +216,6 @@ renderPlot(
     comp <- s.comp
     peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
     s <- summarize.component(peds)
-    
     s$ml.hz.plot
   }
 )
@@ -229,7 +228,7 @@ renderPlot(
 renderTable( {
   sourcemu <- input$s.mu 
   peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
-  df <- categorical.prop.table(peds$hillslope_pos)
+  df <- categorical.prop.table(peds$hillslopeprof)
   df
 }, striped=T)
 
@@ -238,7 +237,7 @@ renderUI( {
   peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
-      print(paste0("Modal pedon value: ",modal$hillslope_pos))
+      print(paste0("Modal pedon value: ",modal$hillslopeprof))
   }
 })
 ```
@@ -248,7 +247,7 @@ renderUI( {
 renderTable( {
   sourcemu <- input$s.mu 
   peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
-  df <- categorical.prop.table(peds$geompos_hill)
+  df <- categorical.prop.table(peds$geomposhill)
   df
 }, striped=T)
 renderUI( {
@@ -256,7 +255,7 @@ renderUI( {
   peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
-      print(paste0("Modal pedon value: ",modal$geompos_hill))
+      print(paste0("Modal pedon value: ",modal$geomposhill))
   }
 })
 ```
@@ -266,7 +265,7 @@ renderUI( {
 renderTable( {
   sourcemu <- input$s.mu 
   peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
-  df <- categorical.prop.table(peds$geompos_mntn)
+  df <- categorical.prop.table(peds$geomposmntn)
   df
 }, striped=T)
 renderUI( {
@@ -274,7 +273,7 @@ renderUI( {
   peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
-      print(paste0("Modal pedon value: ",modal$geompos_mntn))
+      print(paste0("Modal pedon value: ",modal$geomposmntn))
   }
 })
 ```
@@ -321,10 +320,8 @@ renderUI( {
 renderTable( {
   sourcemu <- input$s.mu 
   peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
-  down <- peds$shapedown
-  acro <- peds$shapeacross
-  levels(down) <- c("V","L","C")
-  levels(acro) <- c("V","L","C")
+  down <- factor(as.character(peds$shapedown),labels =  c("V","L","C"), levels=c("convex","linear","concave"))
+  acro <- factor(as.character(peds$shapeacross),labels =  c("V","L","C"), levels=c("convex","linear","concave"))
   shape <- factor(paste(as.character(down),as.character(acro),sep="/"))
   shape[grepl(shape,pattern="NA")] <- NA
   shape <- factor(shape)

--- a/inst/reports/region2/shiny-pedon-summary/shiny.Rmd
+++ b/inst/reports/region2/shiny-pedon-summary/shiny.Rmd
@@ -46,10 +46,25 @@ renderUI( {
   s.pedons <<- getMapunitPedons(input$s.mu)
   inputPanel( {textInput("component_name",label="Component name:",value=".") })
 })
+
 renderUI( {
   inputPanel( {
     textInput("pedon_pattern",label="Pattern for matching pedon taxonname:",value=".") 
   })
+})
+
+renderUI( {
+  inputPanel( {
+    textInput("phase_pattern",label="Pattern for matching pedon local phase:",value=".") 
+  })
+})
+
+renderUI( {
+  inputPanel({
+    foo <- input$s.mu
+    selectInput("taxon_kind", label = "Select taxon kind: ",
+                choices = c("any","family","series","taxadjunct","taxon above family")) 
+    })
 })
 
 renderUI( {  
@@ -67,7 +82,7 @@ renderUI( {
 renderUI( {
   inputPanel({
     foo <- input$s.mu
-    peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+    peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
     selectInput("modal_pedon", label = "Select modal pedon (peiid:userpedonid): ",
                 choices = paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")) 
                 #TODO: Is it possible to set default to the pedon currently tagged to component? 
@@ -104,13 +119,13 @@ renderPlot(
   {
     sourcemu <- input$s.mu #ensures that plotting relies on selected MU (ensures reactive update when mu is changed)
     comp <- s.comp
-    peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+    peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
     
     groupedProfilePlot(peds,groups = 'taxonname', label='pedon_id', 
                          print.id = TRUE, id.style = 'side', cex.id=1.2, 
                          cex.names=1, cex.depth.axis=1.25,y.offset=7, 
                          axis.line.offset=-3.0, group.name.cex=1, 
-                         group.name.offset = -6, color=input$thematic_field,
+                         group.name.offset = c(-6,-10), color=input$thematic_field,
                          width=0.1,shrink=T,shrink.cutoff=3)
       options=list(
         width="100%", height=700
@@ -124,7 +139,7 @@ renderPlot(
 renderLeaflet({
     sourcemu <- input$s.mu #ensures that plotting relies on selected MU (ensures reactive update when mu is changed)
     comp <- s.comp
-    peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+    peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
     pedon_locations <- as(peds,'SpatialPointsDataFrame')
     mapview(pedon_locations)@map #  here we just access the leaflet map slot directly for shiny rendering and use renderLeaflets
 })
@@ -138,7 +153,7 @@ renderPlot(
   {
     sourcemu <- input$s.mu 
     comp <- s.comp
-    peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+    peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
     
     s <- slab(peds, fm = as.formula(paste0(" ~ ",input$thematic_field)))
     
@@ -178,13 +193,13 @@ renderPlot(
   {
     sourcemu <- input$s.mu 
     comp <- s.comp
-    peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+    peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
     peds$genhzraw <- as.character(peds$genhz) #this plot function gets mad if name is a factor...
     groupedProfilePlot(peds,name='genhzraw',groups = 'taxonname', label='pedon_id', 
                          print.id = TRUE, id.style = 'side', cex.id=1.2, 
                          cex.names=1, cex.depth.axis=1.25,y.offset=7, 
                          axis.line.offset=-3.0, group.name.cex=1, 
-                         group.name.offset = -6, color=input$thematic_field,
+                         group.name.offset = c(-6,-10), color=input$thematic_field,
                          width=0.1,shrink=T,shrink.cutoff=3)
       options=list(
         width="100%", height=700
@@ -199,7 +214,7 @@ renderPlot(
   {
     sourcemu <- input$s.mu 
     comp <- s.comp
-    peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+    peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
     s <- summarize.component(peds)
     
     s$ml.hz.plot
@@ -213,14 +228,14 @@ renderPlot(
 ```{r}
 renderTable( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   df <- categorical.prop.table(peds$hillslope_pos)
   df
 }, striped=T)
 
 renderUI( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
       print(paste0("Modal pedon value: ",modal$hillslope_pos))
@@ -232,13 +247,13 @@ renderUI( {
 ```{r}
 renderTable( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   df <- categorical.prop.table(peds$geompos_hill)
   df
 }, striped=T)
 renderUI( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
       print(paste0("Modal pedon value: ",modal$geompos_hill))
@@ -250,13 +265,13 @@ renderUI( {
 ```{r}
 renderTable( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   df <- categorical.prop.table(peds$geompos_mntn)
   df
 }, striped=T)
 renderUI( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
       print(paste0("Modal pedon value: ",modal$geompos_mntn))
@@ -268,13 +283,13 @@ renderUI( {
 ```{r}
 renderTable( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   df <- categorical.prop.table(peds$gis_geomorphons)
   df
 }, striped=T)
 renderUI( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
       print(paste0("Modal pedon value: ",modal$gis_geomorphons))
@@ -286,14 +301,14 @@ renderUI( {
 ```{r}
 renderTable( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   df <- categorical.prop.table(peds$drainagecl)
   df
 }, striped=T)
 
 renderUI( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
       print(paste0("Modal pedon value: ",modal$drainagecl))
@@ -305,7 +320,7 @@ renderUI( {
 ```{r}
 renderTable( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   down <- peds$shapedown
   acro <- peds$shapeacross
   levels(down) <- c("V","L","C")
@@ -319,7 +334,7 @@ renderTable( {
 
 renderUI( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
       print(paste0("Modal pedon value: ",modal$shapedown,modal$shapeacross))
@@ -331,14 +346,14 @@ renderUI( {
 ```{r}
 renderPlot({
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   if(nrow(site(peds)) > 2)
     aspect.plot(peds$aspect_field, q=p.low.rv.high, plot.title=input$pedon_pattern, pch=21, bg='RoyalBlue', col='black', arrow.col=c('grey', 'red', 'grey'))
 })
 
 renderUI( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
       print(paste0("Modal pedon value: ",modal$aspect_field))
@@ -352,14 +367,14 @@ renderUI( {
 ```{r}
 renderTable( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   df <-  categorical.prop.table(peds$ecositeid)
   df
 }, striped=T)
 
 renderUI( {
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
       print(paste0("Modal pedon value: ",modal$ecositeid))
@@ -376,7 +391,7 @@ TODO: Print component plant data
 ```{r} 
 renderTable({
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   xtable(table(peds$genhz,peds$hzname))
 })
 ```
@@ -385,7 +400,7 @@ renderTable({
 ```{r}
 renderPlot({
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list) 
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern) 
   # convert contingency table -> adj. matrix
   m <- genhzTableToAdjMat(table(peds$genhz,peds$hzname))
   
@@ -399,7 +414,7 @@ renderPlot({
 #### Modal pedon (field horizonation : generalized horizonation)
 renderPlot({
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   par(mar=c(1,1,1,1))
   if(!is.na(input$modal_pedon)) {
       modal <- peds[which(input$modal_pedon == paste(site(peds)$peiid,site(peds)$pedon_id,sep=":")),] 
@@ -421,7 +436,7 @@ renderPlot({
 ```{r}
 renderTable({
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   s <- summarize.component(peds)
   df <- s$tt
   df
@@ -429,7 +444,7 @@ renderTable({
 
 renderPlot({
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   
   plot(texture.triangle.low.rv.high(data.frame(sand=peds$sand,silt=peds$silt,clay=peds$clay), p=c(0.05, 0.5, 0.95)))
 })
@@ -439,7 +454,7 @@ renderPlot({
 ```{r}
 renderPlot({
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   aggregateColorPlot(aggregateColor(peds, groups = 'genhz', col = 'soil_color'), label.font = 2, label.cex = 0.95, print.n.hz = TRUE)
 })
 ```
@@ -448,7 +463,7 @@ renderPlot({
 ```{r}
 renderTable({
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   s <- summarize.component(peds)
   df <- s$rt
   df
@@ -459,7 +474,7 @@ renderTable({
 ```{r}
 renderTable({
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   s <- summarize.component(peds)
   df <- s$sf
   df
@@ -470,7 +485,7 @@ renderTable({
 ```{r}
 renderTable({
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   s <- summarize.component(peds)
   df <- s$dt
   df
@@ -481,7 +496,7 @@ renderTable({
 ```{r}
 renderPlot({
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   
   diagnosticPropertyPlot2(peds, v=c('lithic.contact', 'paralithic.contact', 'argillic.horizon', 'cambic.horizon', 'ochric.epipedon', 'mollic.epipedon', 'very.shallow', 'shallow', 'mod.deep', 'deep', 'very.deep'), k=4)
 })
@@ -491,7 +506,7 @@ renderPlot({
 ```{r}
 renderPlot({
   sourcemu <- input$s.mu 
-  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list)
+  peds <- getPedonsByPattern(input$pedon_pattern,input$upid_pattern,input$pedon_list,input$taxon_kind,input$phase_pattern)
   s <- summarize.component(peds)
   print(s$pmg)
 })

--- a/inst/reports/region2/shiny-pedon-summary/utility_functions.R
+++ b/inst/reports/region2/shiny-pedon-summary/utility_functions.R
@@ -10,11 +10,10 @@ getPedonsByPattern <- function(compname,upid,pedon_list,taxon_kind,phasename) {
   upidmatch <- grepl(pattern=upid,s.pedons$pedon_id)
   compmatch <- grepl(pattern=compname,s.pedons$taxonname)
   phasematch <- grepl(pattern=phasename,s.pedons$localphase)
-  
   if(taxon_kind == "any") {
     taxon_kind = ".*"
   }
-  taxkindmatch <- grepl(pattern=taxon_kind, s.pedons$taxon_kind)
+  taxkindmatch <- grepl(pattern=taxon_kind, s.pedons$taxonkind)
   
   idx.match=rep(TRUE, length(s.pedons$pedon_id))
   if(pedon_list != "." & pedon_list != "") { #If there has been a list of pedons specified, use that in lieu of all other patterns
@@ -25,7 +24,8 @@ getPedonsByPattern <- function(compname,upid,pedon_list,taxon_kind,phasename) {
   } else {
     idx.match <- upidmatch & compmatch & phasematch & taxkindmatch
   }
-
+  
+  
   peds <- s.pedons[idx.match,]
   peds$musym <- peds$MUSYM #TODO: trace this to see what functions rely on lowercase 'musym'
   
@@ -363,7 +363,7 @@ summarize.component <- function(f.i) {
   names(texture.table) <- c('Generalized HZ', 'Texture Classes')
   
   # diagnostic hz tables
-  diag.hz.table <- ddply(diagnostic_hz(f.i), c('diag_kind'), .fun=diagnostic.hz.summary, p=getOption('p.low.rv.high'), qt=getOption('q.type'))
+  diag.hz.table <- ddply(diagnostic_hz(f.i), c('featkind'), .fun=diagnostic.hz.summary, p=getOption('p.low.rv.high'), qt=getOption('q.type'))
   names(diag.hz.table) <- c('kind', 'N', 'top', 'bottom', 'thick')
   
   ## ML-horizonation

--- a/inst/reports/region2/shiny-pedon-summary/utility_functions.R
+++ b/inst/reports/region2/shiny-pedon-summary/utility_functions.R
@@ -7,8 +7,8 @@ getMapunitPedons <- function(targetmu) {
 getPedonsByPattern <- function(compname,upid,pedon_list) {
   peds <- data.frame()
   
-  upidmatch <- grepl(pattern=upid,s.pedons$pedon_id)
-  compmatch <- grepl(pattern=compname,s.pedons$taxonname)
+  upidmatch <- grepl(pattern=upid, s.pedons$pedon_id)
+  compmatch <- grepl(pattern=compname, s.pedons$taxonname)
   
   idx.match=rep(TRUE, length(s.pedons$pedon_id))
   if(pedon_list != "." & pedon_list != "") { #If there has been a list of pedons specified, use that in lieu of compname/upid pattern

--- a/inst/reports/region2/shiny-pedon-summary/utility_functions.R
+++ b/inst/reports/region2/shiny-pedon-summary/utility_functions.R
@@ -4,21 +4,28 @@ getMapunitPedons <- function(targetmu) {
   return(pedons[grepl(targetmu,pedons$MUSYM)]) #set of pedons from target MU
 }
 
-getPedonsByPattern <- function(compname,upid,pedon_list) {
+getPedonsByPattern <- function(compname,upid,pedon_list,taxon_kind,phasename) {
   peds <- data.frame()
   
-  upidmatch <- grepl(pattern=upid, s.pedons$pedon_id)
-  compmatch <- grepl(pattern=compname, s.pedons$taxonname)
+  upidmatch <- grepl(pattern=upid,s.pedons$pedon_id)
+  compmatch <- grepl(pattern=compname,s.pedons$taxonname)
+  phasematch <- grepl(pattern=phasename,s.pedons$localphase)
+  
+  if(taxon_kind == "any") {
+    taxon_kind = ".*"
+  }
+  taxkindmatch <- grepl(pattern=taxon_kind, s.pedons$taxon_kind)
   
   idx.match=rep(TRUE, length(s.pedons$pedon_id))
-  if(pedon_list != "." & pedon_list != "") { #If there has been a list of pedons specified, use that in lieu of compname/upid pattern
-    plist <- strsplit(pedon_list,",",fixed=T) #TODO use regex and handle whitespace before or after comma in list
+  if(pedon_list != "." & pedon_list != "") { #If there has been a list of pedons specified, use that in lieu of all other patterns
+    plist <- strsplit(pedon_list,",",fixed=T) #TODO use regex and handle whitespace before or after comma in list?
     if(length(plist[[1]]) >= 1) { #length should always be 1 or more?
-      idx.match = (s.pedons$pedon_id %in% plist[[1]]) #should this allow for regex too? would comma-delimited regex patterns be potentially ambiguous?
+      idx.match = (s.pedons$pedon_id %in% plist[[1]]) #should this allow for regex too? would comma-delimited regex patterns be potentially ambiguous? comma not a special char
     }
   } else {
-    idx.match <- upidmatch & compmatch
+    idx.match <- upidmatch & compmatch & phasematch & taxkindmatch
   }
+
   peds <- s.pedons[idx.match,]
   peds$musym <- peds$MUSYM #TODO: trace this to see what functions rely on lowercase 'musym'
   
@@ -26,11 +33,12 @@ getPedonsByPattern <- function(compname,upid,pedon_list) {
   #TODO: support interactive development of genhz pattern? 
   #TODO: support probabilistic assignment of GHZ?  using permutation of hz assignment and optimizing on "reliability" factor??
   
-  #SET NA genhz from NASIS to not used, to ensure report will run regardless of NASIS db status
+  #SET NA genhz from NASIS to not used, to ensure report will run regardless of NASIS db status 
   horizons(peds)$genhz[is.na(horizons(peds)$genhz)] <- "not-used"
   
   #NOTE: explicitly makes genhz a factor to preserve ordering so that alphabetical order does not take precedent?
-  #               would it be possible to infer genhz order based on how they are used in the modal pedon? for cases where non-regex ghz is applied
+  #       for cases where non-regex ghz is applied would it be possible to _infer_ genhz order based on a modal pedon?
+  
   if(use_regex_ghz) {
     newhz <- c(gen.hz.rules[[1]]$n,'not-used')
     horizons(peds)$genhz <- newhz[as.numeric(generalize.hz(x=peds$hzname,new=gen.hz.rules[[1]]$n,pat=gen.hz.rules[[1]]$p))]
@@ -307,6 +315,9 @@ summarize.component <- function(f.i) {
   ## surface fragment summary
   pedon.surface.frags.table <- summarise.pedon.surface.frags(site.i)
   
+  #make not-used placeholder values na
+  #h.i$genhz[h.i$genhz == 'not-used'] <- NA
+  
   # ## check for missing genhz labels by pedon
   missing.all.genhz.IDs <- ddply(h.i, 'pedon_id', function(i) all(is.na(i$genhz)))
   missing.some.genhz.IDs <- ddply(h.i, 'pedon_id', function(i) any(is.na(i$genhz)))
@@ -337,6 +348,7 @@ summarize.component <- function(f.i) {
   
   # drop values not associated with a generalized horizon label
   h.i.long <- subset(h.i.long, subset=!is.na(genhz))
+  h.i.long <- subset(h.i.long, subset=!(genhz=='not-used'))
   
   # summary by variable / generalized hz label
   s.i <- ddply(h.i.long, c('variable', 'genhz'), .fun=conditional.l.rv.h.summary, p=getOption('p.low.rv.high'), qt=getOption('q.type'))
@@ -361,6 +373,9 @@ summarize.component <- function(f.i) {
   
   # extract original horizon designations and order
   original.levels <- attr(gen.hz.aggregate, 'original.levels')
+  
+  #drop not-used level
+   original.levels <- original.levels[original.levels != 'not-used']
   
   # melt into long format, accomodating illegal column names (e.g. 2Bt)
   gen.hz.aggregate.long <- melt(gen.hz.aggregate, id.vars='top', measure.vars=make.names(original.levels))
@@ -392,7 +407,7 @@ summarize.component <- function(f.i) {
   
   
   # generate ML hz table
-  gen.hz.ml <- get.ml.hz(gen.hz.aggregate)
+  gen.hz.ml <- get.ml.hz(gen.hz.aggregate, original.levels)
   
   # combine all genhz levels with those in the ML hz table
   gzml <- data.frame(hz=factor(original.levels, levels=original.levels))	


### PR DESCRIPTION
shiny-pedon-summary now supports filtering pedon records based on local phase regex pattern matching.

also, it is up to date with the most recent version of soilDB (changes to column names, uncode() etc.)