### PR TITLE
New sanity checks for the mapunit comparison report for large numbers of MUSYM

### DIFF
--- a/R/graphics.R
+++ b/R/graphics.R
@@ -10,6 +10,10 @@
 scaled.density <- function(d, constantScaling=TRUE) {
   # basic density estimate
   v <- na.omit(d$value)
+  
+  if(length(v) <= 1)
+    res <- stats::density(v, kernel='gaussian', bw = 1)
+    
   res <- stats::density(v, kernel='gaussian', adjust=1.5)
   
   # optionally re-scale to {0,1}

--- a/R/graphics.R
+++ b/R/graphics.R
@@ -11,10 +11,11 @@ scaled.density <- function(d, constantScaling=TRUE) {
   # basic density estimate
   v <- na.omit(d$value)
   
-  if(length(v) <= 1)
+  if(length(v) <= 1){
     res <- stats::density(v, kernel='gaussian', bw = 1)
-    
-  res <- stats::density(v, kernel='gaussian', adjust=1.5)
+  } else {
+    res <- stats::density(v, kernel='gaussian', adjust=1.5)
+  }
   
   # optionally re-scale to {0,1}
   if(constantScaling)

--- a/R/multivariate.R
+++ b/R/multivariate.R
@@ -23,7 +23,7 @@ findSafeVars <- function(x, id, tol=1e-5) {
   v <- lapply(xl, function(i) {
     
     # compute SD by variable, after removing ID columns
-    low.sd <- lapply(i[, non.id.vars], function(j) {
+    low.sd <- lapply(i[, non.id.vars, drop = FALSE], function(j) {
       i.sd <- sd(j, na.rm = TRUE)
       return(i.sd < tol)
     } )
@@ -42,7 +42,7 @@ findSafeVars <- function(x, id, tol=1e-5) {
   if(length(v) > 0) {
     # remove from names
     idx <- match(v, non.id.vars)
-    non.id.vars <- non.id.vars[- idx]
+    non.id.vars <- non.id.vars[-idx]
   }
   
   return(non.id.vars)

--- a/R/multivariate.R
+++ b/R/multivariate.R
@@ -30,14 +30,14 @@ findSafeVars <- function(x, id, tol=1e-5) {
     
     # treat 0 length as 0 variance
     if (length(low.sd) == 0)
-      return(NA)
+      return(names(i[, non.id.vars]))
     
     # get variable names associated with low SD
     bad.vars <- names(which(sapply(low.sd, isTRUE)))
   })
   
-  # reduce and get unique names; omit 0 length == NA
-  v <- unique(na.omit(unlist(v)))
+  # reduce and get unique names
+  v <- unique(unlist(v))
   
   if(length(v) > 0) {
     # remove from names

--- a/R/multivariate.R
+++ b/R/multivariate.R
@@ -12,7 +12,7 @@ findSafeVars <- function(x, id, tol=1e-5) {
   n <- names(x)
   
   # find non-id vars
-  non.id.vars <- n[- match(id, n)]
+  non.id.vars <- n[-match(id, n)]
   
   # test must be applied over IDs
   # the group ID must be the first ID in `id`
@@ -24,17 +24,20 @@ findSafeVars <- function(x, id, tol=1e-5) {
     
     # compute SD by variable, after removing ID columns
     low.sd <- lapply(i[, non.id.vars], function(j) {
-      i.sd <- sd(j, na.rm=TRUE)
+      i.sd <- sd(j, na.rm = TRUE)
       return(i.sd < tol)
     } )
     
+    # treat 0 length as 0 variance
+    if (length(low.sd) == 0)
+      return(NA)
     
     # get variable names associated with low SD
     bad.vars <- names(which(sapply(low.sd, isTRUE)))
   })
   
-  # reduce and get unique names
-  v <- unique(unlist(v))
+  # reduce and get unique names; omit 0 length == NA
+  v <- unique(na.omit(unlist(v)))
   
   if(length(v) > 0) {
     # remove from names

--- a/R/reportInit.R
+++ b/R/reportInit.R
@@ -148,7 +148,7 @@ reportUpdate <- function(reportName, outputDir=NULL) {
   if(dir.exists(outputDir))
     reportInit(reportName, outputDir, overwrite = TRUE, updateReport = TRUE)
   else {
-    message(sprintf("%s does not exist -- creating new report instance"))
+    message(sprintf("%s does not exist -- creating new report instance", reportName))
     reportInit(reportName, outputDir, overwrite = TRUE, updateReport = FALSE)
   }
     

--- a/inst/reports/region2/mu-comparison/report.Rmd
+++ b/inst/reports/region2/mu-comparison/report.Rmd
@@ -35,6 +35,14 @@ if (sum(as.numeric(loaded)) != length(packz)) {
   geterrmessage()
 }
 
+### SANITY CHECK #2: make sure required report files are present
+required_src_files <- c("custom.R", "config.R", "categorical_definitions.R") 
+required_src <- required_src_files %in% list.files()
+
+if (any(!required_src)) {
+  stop("Required report files (%s) are missing in current directory (%s). Re-install your report instance with `soilReports::reportInit()`", paste0(required_src_files[required_src], collapse=","), getwd(), call. = FALSE)
+}
+
 ## load report-specific functions
 source('custom.R')
 
@@ -43,9 +51,18 @@ source('custom.R')
 # TODO: allow for batching from a basic report.Rmd
 source('config.R')
 
-### SANITY CHECK #2 - make sure the shapefile to be summarized exists and has the specified column
+# load the structures that define value:label:color for categorical plot. 
+#this defines the aliases and label:value:color sets for displaying categorical variables
+categorical.defs <- list()
+source("categorical_definitions.R") 
+#  updates the "section_toggle" variable defined at top of report 
+#  which will knit the appropriate plots for the specified categoricals from config.R
+
+
+### SANITY CHECK #3 - make sure the shapefile to be summarized exists and has the specified column
 ## load map unit polygons from OGR data source
 mu <- try(readOGR(dsn=mu.dsn, layer = mu.layer, stringsAsFactors = FALSE))
+
 if (class(mu) == 'try-error')
   stop(paste0('Cannot read map unit polygon/feature file: "', 
               mu.dsn, ' / ', mu.layer, '"'), call. = FALSE)
@@ -94,15 +111,16 @@ if (exists('mu.set')) {
 
 
 ### -----
-### Sanity check #4 - make sure output paths are valid (no illegal characters)
+### SANITY CHECK #4 - make sure output paths are valid (no illegal characters)
 ###
 # make an output directory if it doesn't exist
 if (!dir.exists('output')) 
   dir.create('./output')
 
-# shapefile output names; NB: writeOGR uses 'output' as the data source name, so just the base file name
-# note: concatenation of mu.set could result in illegal (too long) file names ~ 130 characters on windows
-# https://github.com/ncss-tech/soilReports/issues/93
+# shapefile/CSV output names; 
+
+# NB: writeOGR uses 'output' as the data source name, so just the base file name
+#     whereas the CSV file names end in .csv
 if (!exists('shp.unsampled.fname')) 
   shp.unsampled.fname <- paste0('un-sampled-', paste(mu.set, collapse='_'))
 if (!exists('shp.stats.fname')) 
@@ -118,6 +136,38 @@ if (!exists('csv.qc.fname'))
   csv.qc.fname <- paste0('poly-qc-', paste(mu.set, collapse='_'),'.csv')
 
 outputfiles <- c(paste0(c(shp.unsampled.fname,shp.stats.fname,shp.qc.fname),".shp"), csv.qc.fname, csv.stats.fname)
+
+# SANITY CHECK #5: let the user know that things might not quite look right with tons of mapunit symbols
+if(length(mu.set) > 8) {
+  warning(sprintf("This report was designed to work with 1 to 8 map units. Found %s in `mu.set`. The report tabular and spatial output is stable for larger numbers of map units, but graphics and colors in the report itself may become cluttered or impossible to interpret.", length(mu.set)), call. = FALSE)
+}
+
+# SANITY CHECK #6: default names do not exceed Windows path length limits
+if (any(nchar(outputfiles) > 260)) {
+  
+  # shapefile containing any unsampled polygons (usually too small or odd shape)
+  shp.unsampled.fname <- 'un-sampled-polygons'
+  
+  # shapefile containing median values / most likely classes by delineation
+  shp.stats.fname <- 'polygons-with-stats'
+  
+  # shapefile containing "proportion of samples outside 5-95% quantile range" by delineation
+  shp.qc.fname <- 'poly-qc'
+  
+  # comma-separated value file containing quantiles by mapunit column level
+  csv.mucol.stats.fname <- 'mucol-stats.csv'
+  
+  # comma-separated value file containing median values / most likely classes by delineation
+  csv.stats.fname <- 'poly-stats.csv'
+  
+  # comma-separated value file containing "proportion of samples outside 5-95% quantile range" by delineation
+  csv.qc.fname <- 'poly-qc.csv'
+  
+  outputfiles <- c(paste0(c(shp.unsampled.fname,shp.stats.fname,shp.qc.fname),".shp"), csv.qc.fname, csv.stats.fname)
+  
+  warning(sprintf("One or more SHP or output file paths exceeds 260 character limit when including all `mu.col` symbols (n = %s) in the name. Reverting to shorter (non-specific) file names. See options in config.R to customize output file names.", length(mu.set)), call. = FALSE)
+}
+
 if (any(grepl(basename(outputfiles), pattern='([/\\|<>:\\*?\"])'))) {
   stop("Map unit set or output file name contains invalid characters for filename. Either override default output filenames in config.R or remove [/\\|<>:\\*?\"] characters from your map unit symbols.", call. = FALSE)
 }
@@ -130,13 +180,17 @@ mu <- mu[, mu.col, drop=FALSE]
 mu$pID <- seq(from=1, to=length(mu))
 
 if(cache.samples & file.exists('cached-samples.Rda')) {
+  
   message('Using cached raster samples...')
   .sampling.time <- 'using cached samples'
   load('cached-samples.Rda')
+  
 } else {
+  
   # suppressing warnings: these have to do with conversion of CRS of points
   # iterate over map units and sample rasters
   # result is a list
+  # 
   .timer.start <- Sys.time()
   sampling.res <- suppressWarnings(sampleRasterStackByMU(mu, mu.set, mu.col, raster.list,
                                                          pts.per.acre, progress = FALSE, 
@@ -170,12 +224,6 @@ if (nrow(d.circ) > 0) { ## TODO: could there ever be more than one type of circu
 d.cat <- subset(sampling.res$raster.samples, variable.type == 'categorical')
 d.cat$.id <- factor(d.cat$.id, levels = mu.set)
 d.cat.sub <- list()
-categorical.defs <- list()#this defines the aliases and label:value:color sets for displaying categorical variables
-
-# load the structures that define value:label:color for categorical plot. 
-source("categorical_definitions.R") 
-#  updates the "section_toggle" variable defined at top of report 
-#  which will knit the appropriate plots for the specified categoricals from config.R
 
 ### FORMATTING
 ## figure out reasonable figure heights for bwplots and density plots

--- a/inst/reports/region2/mu-comparison/setup.R
+++ b/inst/reports/region2/mu-comparison/setup.R
@@ -10,11 +10,13 @@
 ## version number
 
 .report.name <- 'mu-comparison'
-.report.version <- '3.3.9'
+.report.version <- '3.4.0'
 .report.description <- 'compare stack of raster data, sampled from polygons associated with 1-8 map units'
 
-.paths.to.copy <- c('report.Rmd','custom.R','config.R','categorical_definitions.R','README.md','changes.txt','create-NASIS-import-files.R')
-.update.paths.to.copy <- c('report.Rmd','custom.R', 'categorical_definitions.R','README.md','changes.txt','create-NASIS-import-files.R')
+.paths.to.copy <- c('report.Rmd','custom.R','config.R','categorical_definitions.R',
+                    'README.md','changes.txt','create-NASIS-import-files.R')
+.update.paths.to.copy <- c('report.Rmd','custom.R', 'categorical_definitions.R',
+                           'README.md','changes.txt','create-NASIS-import-files.R')
 
 .packages.to.get <- c('knitr', 'rmarkdown', 'rgdal', 'reshape2', 'raster', 'plyr', 'Hmisc', 'aqp', 'soilDB', 'sharpshootR', 'latticeExtra', 'clhs', 'devtools', 'rgeos', 'randomForest', 'vegan', 'spdep', 'scales', 'e1071','RColorBrewer')
 


### PR DESCRIPTION
Install this branch to get the files that support greater stability in Region 2 Mapunit Comparison Report v3.4.0

`remotes::install_github('ncss-tech/soilReports@mucompSanity', dependencies=FALSE)`

Install or Update Report Instance:
`soilReports::reportInit('region2/mu-comparison', outputDir = 'new-mucomp-folder')`

`soilReports::reportUpdate('region2/mu-comparison', outputDir = 'existing-mucomp-folder')`